### PR TITLE
- Put the different components in its own file

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialog.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialog.tsx
@@ -1,18 +1,6 @@
 import React from 'react';
-import { 
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Typography,
-  Button,
-  Box,
-  Divider,
-  List,
-  ListItem,
-  ListItemText
-} from '@mui/material';
 import type { VersionInfo } from '../../hooks/useVersionCheck';
+import VersionDialogBox from './VersionDialogBox';
 
 interface VersionDialogProps {
   versionInfo: VersionInfo | null;
@@ -31,68 +19,10 @@ export const VersionDialog: React.FC<VersionDialogProps> = ({
 }) => {
   if (!versionInfo || !open) return null;
   
-  const formatDate = (dateString: string) => {
-    try {
-      const date = new Date(dateString);
-      return date.toLocaleDateString('nb-NO', { 
-        year: 'numeric', 
-        month: 'long', 
-        day: 'numeric' 
-      });
-    } catch {
-      return dateString;
-    }
-  };
-
   return (
-    <Dialog
+    <VersionDialogBox
+      versionInfo={versionInfo}
       open={open}
-      onClose={onClose}
-      maxWidth="md"
-      fullWidth
-      aria-labelledby="version-dialog-title"
-    >
-      <DialogTitle id="version-dialog-title">
-        <Typography variant="h5" component="div">
-          Ny versjon: {versionInfo.version} 🎉🥳
-        </Typography>
-        <Typography variant="subtitle1" color="text.secondary">
-          Versjon {versionInfo.version} ble lansert {formatDate(versionInfo.releaseDate)}
-        </Typography>
-      </DialogTitle>
-      
-      <DialogContent dividers>
-
-        
-        {/* Viser kun den første (nyeste) endringen i listen */}
-        {versionInfo.changes.length > 0 && (
-          <Box >
-            <Typography variant="h6">
-              {versionInfo.changes[0].title}
-            </Typography>
-            
-            <Typography variant="body2" paragraph>
-              {versionInfo.changes[0].description}
-            </Typography>
-            
-            {versionInfo.changes[0].details.length > 0 && (
-              <List dense>
-                {versionInfo.changes[0].details.map((detail, detailIndex) => (
-                  <ListItem key={detailIndex}>
-                    <ListItemText primary={detail} />
-                  </ListItem>
-                ))}
-              </List>
-            )}
-          </Box>
-        )}
-      </DialogContent>
-      
-      <DialogActions>
-        <Button variant="contained" color="primary" onClick={onClose} autoFocus>
-          Ikke vis igjen
-        </Button>
-      </DialogActions>
-    </Dialog>
+      onClose={onClose}/>
   );
 };

--- a/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialogBox.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialogBox.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { 
+  Dialog
+} from '@mui/material';
+import type { VersionInfo } from '../../hooks/useVersionCheck';
+import VersionDialogTitle  from './VersionDialogTitle';
+import VersionDialogContent from './VersionDialogContent';
+import VersionDialogButton from './VersionDialogButton';
+
+
+interface VersionDialogBoxProps {
+    versionInfo: VersionInfo | null;
+    open: boolean;
+    onClose: () => void;
+}
+
+
+const VersionDialogBox: React.FC<VersionDialogBoxProps> =({
+    versionInfo,
+    open,
+    onClose
+}) => {
+    if (!versionInfo || !open) return null;
+    return (
+    <Dialog
+        open={open}
+        onClose={onClose}
+        maxWidth="md"
+        fullWidth
+        aria-labelledby="version-dialog-title"
+    >
+        <VersionDialogTitle versionInfo={versionInfo} />
+      <VersionDialogContent versionInfo={versionInfo} />
+      <VersionDialogButton onClose={onClose} />
+    </Dialog>
+  );
+}
+
+export default VersionDialogBox;

--- a/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialogButton.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialogButton.tsx
@@ -1,0 +1,20 @@
+import { 
+    Button, 
+    DialogActions 
+} from "@mui/material";
+
+
+type VersionDialogButtonProps = {
+    onClose: () => void;
+}
+
+const VersionDialogButton: React.FC<VersionDialogButtonProps> = ({ onClose }) => {
+    return (
+        <DialogActions>
+        <Button variant="contained" color="primary" onClick={onClose} >
+          Ikke vis igjen
+        </Button>
+        </DialogActions>
+    );
+};
+export default VersionDialogButton;

--- a/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialogContent.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialogContent.tsx
@@ -1,0 +1,41 @@
+import { 
+    Box, 
+    List, 
+    Typography,
+    ListItem, 
+    ListItemText,
+    DialogContent
+} from "@mui/material";
+import type { VersionInfo } from "../../hooks/useVersionCheck";
+
+type VersionDialogContentProps = {
+    versionInfo: VersionInfo | null;
+}
+
+const VersionDialogContent: React.FC<VersionDialogContentProps> = ({versionInfo}) => {
+    return (
+        <DialogContent dividers>
+            {versionInfo.changes.length >0 && (
+                <Box>
+                    <Typography variant = "h6">
+                        {versionInfo.changes[0].title}
+                    </Typography>
+                    <Typography variant = "body2">
+                        {versionInfo.changes[0].description}
+                    </Typography>
+                    {versionInfo.changes[0].details.length > 0 && (
+                    <List dense>
+                            {versionInfo.changes[0].details.map((detail, index) => (
+                                <ListItem key={index}>
+                                    <ListItemText primary={detail} />
+                                </ListItem>
+                            ))}
+                        </List>
+                    )}
+                </Box>
+            )}
+        </DialogContent>
+    );
+};
+
+export default VersionDialogContent;

--- a/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialogTitle.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/VersionDialog/VersionDialogTitle.tsx
@@ -1,0 +1,24 @@
+import { DialogTitle, Typography } from "@mui/material";
+import formatDate from "./utils/formatDateutils";
+import { VersionInfo } from "../../hooks/useVersionCheck";
+
+type VersionDialogTitleProps = {
+    versionInfo: VersionInfo | null;
+}
+
+const VersionDialogTitle: React.FC<VersionDialogTitleProps> = ({
+    versionInfo
+}) => {
+    return (
+        <DialogTitle id = "version-dialog-title">
+            <Typography variant="h5" component="div">
+                Ny versjon: {versionInfo.version} 🎉🥳
+            </Typography>
+            <Typography variant="subtitle1" color="text.secondary">
+                Versjon {versionInfo.version} ble lansert {formatDate(versionInfo.releaseDate)}
+            </Typography>
+        </DialogTitle>
+    )
+};
+
+export default VersionDialogTitle;

--- a/frontend/altinn-support-dashboard.client/src/components/VersionDialog/utils/formatDateutils.ts
+++ b/frontend/altinn-support-dashboard.client/src/components/VersionDialog/utils/formatDateutils.ts
@@ -1,0 +1,15 @@
+
+const formatDate = (dateString: string) => {
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString('nb-NO', { 
+        year: 'numeric', 
+        month: 'long', 
+        day: 'numeric' 
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
+  export default formatDate


### PR DESCRIPTION
- Cleaned up VersionDialog and split the structure into their own files

- Made a new file for the Date formating

- VersionDialog now only holds one component that handles the other components
