### PR TITLE
219 Not possible to scroll with many hits on a search

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/organizations/OrganizationList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/organizations/OrganizationList.tsx
@@ -46,7 +46,7 @@ export const OrganizationList: React.FC<OrganizationListProps> = ({
 
   // Default case: render organizations
   return (
-    <div className={`org-list`}>
+    <div className={`org-list`} style={{ overflowY: "auto", maxHeight: "80vh" }}>
       {organizations
         .filter((org) => {
           // filter out subunits if parent is already included


### PR DESCRIPTION
Fixed so the organization list will handle overflow automatic and that the list will take up 80% of the allocated space heightwise. When there's too many variables to be contained on one page, it will create a scroll to see all the variables
