### PR TITLE
+ sign is now ignored when searching with countrycodes

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/components/TopSearchBar/TopSearchBarTextField.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/TopSearchBar/TopSearchBarTextField.tsx
@@ -10,7 +10,12 @@ type Props = {
 export const TopSearchBarTextField: React.FC<Props> = ({ query, setQuery }) => {
   const [textFieldValue, setTextFieldValue] = useState("");
   const handleSearch = () => {
-    setQuery(textFieldValue);
+    //Ignores + for countrycodes for phonenumbers
+    if (textFieldValue[0] === "+") {
+      setQuery(textFieldValue.slice(1));
+    } else {
+      setQuery(textFieldValue);
+    }
   };
 
   useEffect(() => {

--- a/frontend/altinn-support-dashboard.client/src/utils/api.ts
+++ b/frontend/altinn-support-dashboard.client/src/utils/api.ts
@@ -8,7 +8,8 @@ export const fetchOrganizations = async (
   environment: string,
   query: string,
 ) => {
-  const trimmedQuery = query.replace(/\s/g, "");
+  var trimmedQuery = query.replace(/\s/g, "");
+
   const res = await authorizedFetch(
     `${getBaseUrl(environment)}/serviceowner/organizations/search?query=${encodeURIComponent(trimmedQuery)}`,
   );
@@ -74,13 +75,15 @@ export const fetchRoles = async (
   return typeof data === "string" ? JSON.parse(data) : data;
 };
 
-export const fetchRolesForOrg = async(
-  environment: string, 
-  rollehaver: string, 
-  rollegiver:string
+export const fetchRolesForOrg = async (
+  environment: string,
+  rollehaver: string,
+  rollegiver: string,
 ) => {
-  const res = await authorizedFetch( `/api/${environment}/serviceowner/${rollehaver}/roles/${rollegiver}`);
-  if (!res.ok) throw new Error(await res.text() || "Error fetching roles");
+  const res = await authorizedFetch(
+    `/api/${environment}/serviceowner/${rollehaver}/roles/${rollegiver}`,
+  );
+  if (!res.ok) throw new Error((await res.text()) || "Error fetching roles");
   const data = await res.json();
   let rolesArray: Role[] = [];
   if (Array.isArray(data)) {
@@ -93,4 +96,5 @@ export const fetchRolesForOrg = async(
     }
   }
   return rolesArray;
-}
+};
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When searching with phonenumbers with + before the countrycode will now be ignored. This ignores the + flatly, which was a easy way to implement this feature without adding alot of bloat for a small feature.
