### PR TITLE
258 refactor migrate rolesdetails to designsystemet

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/RoleDetails.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/RoleDetails.tsx
@@ -1,19 +1,14 @@
 import React from "react";
-import {
-  Button,
-  Paper,
-  Table as MuiTable,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from "@mui/material";
 import { useRoles } from "../../../hooks/hooks";
 import { PersonalContact } from "../models/mainContentTypes";
 import { useAppStore } from "../../../stores/Appstore";
 import RoleTypeCell from "../../RoleTypeCell";
+import { Button, 
+  Heading,
+  Table,
+  Card,
+  Paragraph
+} from '@digdir/designsystemet-react'
 
 interface RoleDetailsProps {
   selectedContact: PersonalContact;
@@ -40,50 +35,42 @@ export const RoleDetails: React.FC<RoleDetailsProps> = ({
 
   return (
     <div>
-      <Typography variant="h6" gutterBottom>
+      <Heading level={2}>
         Roller knyttet til {selectedContact.name}
-      </Typography>
+      </Heading>
 
-      <Button variant="outlined" onClick={handleBack} sx={{ mb: 2 }}>
+      <Button variant="secondary" onClick={handleBack}>
         Tilbake til oversikt
       </Button>
 
-      <TableContainer component={Paper} sx={{ mb: 2 }}>
-        <MuiTable>
-          <TableHead>
-            <TableRow>
-              <TableCell>
-                <Typography variant="subtitle1">Rolletype</Typography>
-              </TableCell>
-              <TableCell>
-                <Typography variant="subtitle1">Rollenavn</Typography>
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
+      <Card>
+        <Table>
+          <Table.Head>
+            <Table.Row>
+              <Table.HeaderCell>Rolletype</Table.HeaderCell>
+              <Table.HeaderCell>Rollenavn</Table.HeaderCell>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
             {roleInfo && roleInfo.length > 0 ? (
               roleInfo.map((role, index) => (
-                <TableRow key={index}>
+                <Table.Row key={index}>
                   <RoleTypeCell roleType={role.RoleType} />
-                  <TableCell>{role.RoleName}</TableCell>
-                </TableRow>
+                  <Table.Cell>{role.RoleName}</Table.Cell>
+                </Table.Row>
               ))
             ) : (
-              <TableRow>
-                <TableCell colSpan={2}>
-                  <Typography
-                    variant="body2"
-                    color="textSecondary"
-                    align="center"
-                  >
+              <Table.Row>
+                <Table.Cell colSpan={2}>
+                  <Paragraph style={{ textAlign: 'center' }}>
                     Ingen roller funnet
-                  </Typography>
-                </TableCell>
-              </TableRow>
+                  </Paragraph>
+                </Table.Cell>
+              </Table.Row>
             )}
-          </TableBody>
-        </MuiTable>
-      </TableContainer>
+          </Table.Body>
+        </Table>
+      </Card>
     </div>
   );
 };

--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/RoleDetails.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/RoleDetails.tsx
@@ -9,6 +9,8 @@ import { Button,
   Card,
   Paragraph
 } from '@digdir/designsystemet-react'
+import containerStyles from "../styles/RoleDetailsContainer.module.css";
+import buttonStyles from "../styles/RoleDetailsButton.module.css"
 
 interface RoleDetailsProps {
   selectedContact: PersonalContact;
@@ -34,17 +36,19 @@ export const RoleDetails: React.FC<RoleDetailsProps> = ({
   };
 
   return (
-    <div>
+    <Card>
       <Heading level={2}>
         Roller knyttet til {selectedContact.name}
       </Heading>
 
-      <Button variant="secondary" onClick={handleBack}>
+      <Button className={buttonStyles["RoleDetailsButton"]} 
+      onClick={handleBack}
+      variant='secondary'>
         Tilbake til oversikt
       </Button>
 
-      <Card>
-        <Table>
+      <div className={containerStyles["RoleDetailsContainer"]}>
+        <Table stickyHeader>
           <Table.Head>
             <Table.Row>
               <Table.HeaderCell>Rolletype</Table.HeaderCell>
@@ -70,7 +74,7 @@ export const RoleDetails: React.FC<RoleDetailsProps> = ({
             )}
           </Table.Body>
         </Table>
-      </Card>
-    </div>
+      </div>
+    </Card>
   );
 };

--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/styles/RoleDetailsButton.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/styles/RoleDetailsButton.module.css
@@ -1,0 +1,10 @@
+
+
+.RoleDetailsButton {
+    margin: 0.5rem 0 1rem 0;
+    height: 2.5rem;
+    font-size: 0.95rem;
+    padding: 0.2rem 0.2rem;
+    min-width: unset;
+    min-height: unset;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/styles/RoleDetailsContainer.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/styles/RoleDetailsContainer.module.css
@@ -1,0 +1,10 @@
+
+
+
+.RoleDetailsContainer {
+    border-color: lightskyblue;
+    border-style: solid;
+    overflow-y: auto;
+    max-height: 60vh;
+    border-width: 0.02rem;
+}


### PR DESCRIPTION
Migrated from MuiComponents to Designsystemet'scomponents
Most of styling si moved to it's own css modules (button and container)