### PR TITLE
REFACTOR: Migrate ErrorAlert to Designsystemet

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/ErrorAlert.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/ErrorAlert.tsx
@@ -1,4 +1,8 @@
-import { Alert, Typography } from "@mui/material";
+import {
+  Alert,
+  Heading,
+  Paragraph
+} from "@digdir/designsystemet-react"
 
 interface ErrorAlertProps {
   error: {
@@ -11,14 +15,14 @@ export const ErrorAlert: React.FC<ErrorAlertProps> = ({ error }) => {
   if (!error?.message) return null;
 
   return (
-    <Alert severity="error" sx={{ mb: 2 }}>
-      <Typography variant="h6" component="div">
+    <Alert data-color="danger">
+      <Heading>
         {error.message}
-      </Typography>
+      </Heading>
       {error.response && (
-        <Typography variant="body2" component="div">
+        <Heading>
           {error.response}
-        </Typography>
+        </Heading>
       )}
     </Alert>
   );


### PR DESCRIPTION
Switched so that ErrorAlert uses componnets from designsystemet instead of MUI