### PR TITLE
302 org numebr covers underenhet button

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/styles/OrganizationCard.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/styles/OrganizationCard.module.css
@@ -7,7 +7,6 @@
   position: absolute;
   right: 10px;
   bottom: 10px;
-  font-size: 1rem;
   padding-top: -0.5;
   min-height: 1rem;
   max-height: 3rem;


### PR DESCRIPTION
Made the button slightly shorter so the orgnumber doesn't go over it when the screen is narrower