### PR TITLE
317 make orgcards smaller when on laptop screen

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/organizations/OrganizationCard.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/organizations/OrganizationCard.tsx
@@ -86,8 +86,8 @@ export const OrganizationCard: React.FC<OrganizationCardProps> = ({
                   })
                 }
               >
-                <Paragraph variant="short">{sub.navn}</Paragraph>
-                <Paragraph variant="short">
+                <Paragraph variant="short" className={classes.cardHeader}>{sub.navn}</Paragraph>
+                <Paragraph variant="short" className={classes.cardParagraph}>
                   Org Nr: {sub.organisasjonsnummer}
                 </Paragraph>
               </Card>

--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/styles/OrganizationCard.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/styles/OrganizationCard.module.css
@@ -55,4 +55,8 @@
   .cardParagraph {
     font-size: var(--ds-font-size-2);
   }
+  .subunit .card{
+    min-height: 5rem;
+    max-height: 6rem;
+  }
 }


### PR DESCRIPTION
Made the expand button samller, and changed the fontsize for the main unit and sub unit on smaller screens