### PR TITLE
feat: add backend endpoint to fetch notifications by order ID          

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Clients/Interfaces/INotificationsClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Interfaces/INotificationsClient.cs
@@ -1,0 +1,5 @@
+public interface INotificationsClient
+{
+    Task<string> GetEmailNotificationsByOrderId(string orderId);
+    Task<string> GetSmsNotificationsByOrderId(string orderId);
+}

--- a/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
@@ -1,0 +1,30 @@
+using altinn_support_dashboard.Server.Models;
+using Microsoft.Extensions.Options;
+
+public class NotificationsClient : INotificationsClient
+{
+    private readonly HttpClient _client;
+    private readonly ILogger<INotificationsClient> _logger;
+
+    public NotificationsClient(IOptions<Configuration> configuration, IHttpClientFactory clientFactory, ILogger<INotificationsClient> logger)
+    {
+        _logger = logger;
+
+        var tt02 = configuration.Value.TT02;
+        _client = clientFactory.CreateClient(nameof(configuration.Value.TT02));
+        _client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", tt02.Ocp_Apim_Subscription_Key);
+        _client.BaseAddress = new Uri(tt02.BaseAddressAltinn3);
+        _client.Timeout = TimeSpan.FromSeconds(tt02.Timeout);
+        _client.DefaultRequestHeaders.Add("ApiKey", tt02.ApiKey);
+    }
+
+    public async Task<string> GetEmailNotificationsByOrderId(string orderId)
+    {
+        return "";
+    }
+
+    public async Task<string> GetSmsNotificationsByOrderId(string orderId)
+    {
+        return "";
+    }
+}

--- a/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
@@ -20,11 +20,27 @@ public class NotificationsClient : INotificationsClient
 
     public async Task<string> GetEmailNotificationsByOrderId(string orderId)
     {
-        return "";
+        var response = await _client.GetAsync($"notifications/api/v1/orders/{orderId}/notifications/email");
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Api request failed with status code {response.StatusCode}: {responseBody}");
+        }
+
+        return responseBody;
     }
 
     public async Task<string> GetSmsNotificationsByOrderId(string orderId)
     {
-        return "";
+        var response = await _client.GetAsync($"notifications/api/v1/orders/{orderId}/notifications/sms");
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Api request failed with status code {response.StatusCode}: {responseBody}");
+        }
+
+        return responseBody;
     }
 }

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -1,0 +1,35 @@
+using altinn_support_dashboard.Server.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Security;
+
+namespace AltinnSupportDashboard.Controllers;
+
+[ApiController]
+[Route("api/notifications")]
+//added authorization temporary
+[Authorize(AnsattportenConstants.AnsattportenAuthorizationPolicy)]
+[Authorize(AnsattportenConstants.AnsattportenTT02AuthorizationPolicy)]
+public class NotificationsController : ControllerBase
+{
+    private readonly INotificationsService _service;
+
+    public NotificationsController(INotificationsService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("email/{orderId}")]
+    public async Task<IActionResult> GetEmailNotificationsByOrderId(string orderId)
+    {
+        var response = await _service.GetEmailNotificationsByOrderId(orderId);
+        return Ok(response);
+    }
+
+    [HttpGet("sms/{orderId}")]
+    public async Task<IActionResult> GetSmsNotificationsByOrderId(string orderId)
+    {
+        var response = await _service.GetSmsNotificationsByOrderId(orderId);
+        return Ok(response);
+    }
+}

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -19,17 +19,24 @@ public class NotificationsController : ControllerBase
         _service = service;
     }
 
-    [HttpGet("email/{orderId}")]
+    [HttpGet("orderid/email/{orderId}")]
     public async Task<IActionResult> GetEmailNotificationsByOrderId(string orderId)
     {
         var response = await _service.GetEmailNotificationsByOrderId(orderId);
         return Ok(response);
     }
 
-    [HttpGet("sms/{orderId}")]
+    [HttpGet("orderid/sms/{orderId}")]
     public async Task<IActionResult> GetSmsNotificationsByOrderId(string orderId)
     {
         var response = await _service.GetSmsNotificationsByOrderId(orderId);
+        return Ok(response);
+    }
+
+    [HttpGet("orderid/{orderId}")]
+    public async Task<IActionResult> GetAllNotificationsByOrderId(string orderId)
+    {
+        var response = await _service.GetAllNotificationsByOrderId(orderId);
         return Ok(response);
     }
 }

--- a/backend/src/altinn-support-dashboard.backend/Models/notifications/NotificationDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/notifications/NotificationDto.cs
@@ -1,0 +1,9 @@
+namespace Models.notifications;
+
+public class NotificationDto
+{
+    public required string Id { get; set; }
+    public required bool Succeeded { get; set; }
+    public required NotificationRecipientDto Recipient { get; set; }
+    public required NotificationSendStatusDto SendStatus { get; set; }
+}

--- a/backend/src/altinn-support-dashboard.backend/Models/notifications/NotificationOrderResponseDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/notifications/NotificationOrderResponseDto.cs
@@ -1,0 +1,10 @@
+namespace Models.notifications;
+
+public class NotificationOrderResponseDto
+{
+    public required string OrderId { get; set; }
+    public required string SendersReference { get; set; }
+    public required int Generated { get; set; }
+    public required int Succeeded { get; set; }
+    public required List<NotificationDto> Notifications { get; set; }
+}

--- a/backend/src/altinn-support-dashboard.backend/Models/notifications/NotificationRecipientDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/notifications/NotificationRecipientDto.cs
@@ -1,0 +1,8 @@
+namespace Models.notifications;
+
+public class NotificationRecipientDto
+{
+    public string? EmailAddress { get; set; }
+    public string? MobileNumber { get; set; }
+    public string? OrganizationNumber { get; set; }
+}

--- a/backend/src/altinn-support-dashboard.backend/Models/notifications/NotificationSendStatusDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/notifications/NotificationSendStatusDto.cs
@@ -1,0 +1,8 @@
+namespace Models.notifications;
+
+public class NotificationSendStatusDto
+{
+    public required string Status { get; set; }
+    public required string Description { get; set; }
+    public required DateTime LastUpdate { get; set; }
+}

--- a/backend/src/altinn-support-dashboard.backend/Program.cs
+++ b/backend/src/altinn-support-dashboard.backend/Program.cs
@@ -102,6 +102,7 @@ namespace AltinnSupportDashboard
                     services.AddScoped<PartyApiClient>();
                     services.AddScoped<IPartyApiService, PartyApiService>();
                     services.AddScoped<INotificationsClient, NotificationsClient>();
+                    services.AddScoped<INotificationsService, NotificationsService>();
                     services.AddScoped<ICorrespondenceClient, CorrespondenceClient>();
                     services.AddScoped<ICorrespondenceService, CorrespondenceService>();
                     services.AddScoped<ISsnTokenService, SsnTokenService>();

--- a/backend/src/altinn-support-dashboard.backend/Program.cs
+++ b/backend/src/altinn-support-dashboard.backend/Program.cs
@@ -101,6 +101,7 @@ namespace AltinnSupportDashboard
                     services.AddScoped<IAltinn3Service, Altinn3Service>();
                     services.AddScoped<PartyApiClient>();
                     services.AddScoped<IPartyApiService, PartyApiService>();
+                    services.AddScoped<INotificationsClient, NotificationsClient>();
                     services.AddScoped<ICorrespondenceClient, CorrespondenceClient>();
                     services.AddScoped<ICorrespondenceService, CorrespondenceService>();
                     services.AddScoped<ISsnTokenService, SsnTokenService>();

--- a/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
@@ -1,0 +1,7 @@
+namespace altinn_support_dashboard.Server.Services.Interfaces;
+
+public interface INotificationsService
+{
+    Task<string> GetEmailNotificationsByOrderId(string orderId);
+    Task<string> GetSmsNotificationsByOrderId(string orderId);
+}

--- a/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
@@ -6,4 +6,5 @@ public interface INotificationsService
 {
     Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId);
     Task<NotificationOrderResponseDto> GetSmsNotificationsByOrderId(string orderId);
+    Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId);
 }

--- a/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
@@ -1,7 +1,9 @@
+using Models.notifications;
+
 namespace altinn_support_dashboard.Server.Services.Interfaces;
 
 public interface INotificationsService
 {
-    Task<string> GetEmailNotificationsByOrderId(string orderId);
-    Task<string> GetSmsNotificationsByOrderId(string orderId);
+    Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId);
+    Task<NotificationOrderResponseDto> GetSmsNotificationsByOrderId(string orderId);
 }

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
@@ -31,4 +31,30 @@ public class NotificationsService : INotificationsService
         var result = await _client.GetSmsNotificationsByOrderId(orderId);
         return JsonSerializer.Deserialize<NotificationOrderResponseDto>(result, _jsonOptions) ?? throw new Exception("Error deserializing SMS notifications response");
     }
+
+    public async Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId)
+    {
+        var smsTask = GetSmsNotificationsByOrderId(orderId);
+        var emailTask = GetEmailNotificationsByOrderId(orderId);
+
+        // runs the tasks in parrallel
+        await Task.WhenAll(
+            smsTask.ContinueWith(_ => { }),
+            emailTask.ContinueWith(_ => { })
+        );
+
+        List<NotificationOrderResponseDto> results = [];
+
+        if (smsTask.IsCompletedSuccessfully)
+            results.Add(smsTask.Result);
+        else
+            _logger.LogError(smsTask.Exception, "Failed to get SMS notifications for order {OrderId}", orderId);
+
+        if (emailTask.IsCompletedSuccessfully)
+            results.Add(emailTask.Result);
+        else
+            _logger.LogError(emailTask.Exception, "Failed to get email notifications for order {OrderId}", orderId);
+
+        return results;
+    }
 }

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
@@ -1,0 +1,25 @@
+using altinn_support_dashboard.Server.Services.Interfaces;
+
+namespace altinn_support_dashboard.Server.Services;
+
+public class NotificationsService : INotificationsService
+{
+    private readonly INotificationsClient _client;
+    private readonly ILogger<INotificationsService> _logger;
+
+    public NotificationsService(INotificationsClient client, ILogger<INotificationsService> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task<string> GetEmailNotificationsByOrderId(string orderId)
+    {
+        return await _client.GetEmailNotificationsByOrderId(orderId);
+    }
+
+    public async Task<string> GetSmsNotificationsByOrderId(string orderId)
+    {
+        return await _client.GetSmsNotificationsByOrderId(orderId);
+    }
+}

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
@@ -1,4 +1,6 @@
 using altinn_support_dashboard.Server.Services.Interfaces;
+using Models.notifications;
+using System.Text.Json;
 
 namespace altinn_support_dashboard.Server.Services;
 
@@ -6,6 +8,11 @@ public class NotificationsService : INotificationsService
 {
     private readonly INotificationsClient _client;
     private readonly ILogger<INotificationsService> _logger;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
 
     public NotificationsService(INotificationsClient client, ILogger<INotificationsService> logger)
     {
@@ -13,13 +20,15 @@ public class NotificationsService : INotificationsService
         _logger = logger;
     }
 
-    public async Task<string> GetEmailNotificationsByOrderId(string orderId)
+    public async Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId)
     {
-        return await _client.GetEmailNotificationsByOrderId(orderId);
+        var result = await _client.GetEmailNotificationsByOrderId(orderId);
+        return JsonSerializer.Deserialize<NotificationOrderResponseDto>(result, _jsonOptions) ?? throw new Exception("Error deserializing email notifications response");
     }
 
-    public async Task<string> GetSmsNotificationsByOrderId(string orderId)
+    public async Task<NotificationOrderResponseDto> GetSmsNotificationsByOrderId(string orderId)
     {
-        return await _client.GetSmsNotificationsByOrderId(orderId);
+        var result = await _client.GetSmsNotificationsByOrderId(orderId);
+        return JsonSerializer.Deserialize<NotificationOrderResponseDto>(result, _jsonOptions) ?? throw new Exception("Error deserializing SMS notifications response");
     }
 }

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
@@ -1,4 +1,5 @@
 using altinn_support_dashboard.Server.Services.Interfaces;
+using altinn_support_dashboard.Server.Utils;
 using Models.notifications;
 using System.Text.Json;
 
@@ -48,12 +49,12 @@ public class NotificationsService : INotificationsService
         if (smsTask.IsCompletedSuccessfully)
             results.Add(smsTask.Result);
         else
-            _logger.LogError(smsTask.Exception, "Failed to get SMS notifications for order {OrderId}", orderId);
+            _logger.LogError(smsTask.Exception, "Failed to get SMS notifications for order {OrderId}", ValidationService.SanitizeForLog(orderId));
 
         if (emailTask.IsCompletedSuccessfully)
             results.Add(emailTask.Result);
         else
-            _logger.LogError(emailTask.Exception, "Failed to get email notifications for order {OrderId}", orderId);
+            _logger.LogError(emailTask.Exception, "Failed to get email notifications for order {OrderId}", ValidationService.SanitizeForLog(orderId));
 
         return results;
     }

--- a/backend/src/altinn-support-dashboard.backend/Utils/InputValidation.cs
+++ b/backend/src/altinn-support-dashboard.backend/Utils/InputValidation.cs
@@ -88,5 +88,17 @@ namespace altinn_support_dashboard.Server.Utils
             return true;
 
         }
+
+
+        public static string SanitizeForLog(string value)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+            // Remove newline and other control characters to prevent log forging.
+            var chars = value.Where(c => !char.IsControl(c) || c == '\t').ToArray();
+            return new string(chars);
+        }
     }
 }

--- a/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
@@ -1,0 +1,97 @@
+using altinn_support_dashboard.Server.Services.Interfaces;
+using AltinnSupportDashboard.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Models.notifications;
+using Moq;
+using Xunit;
+
+namespace altinn_support_dashboard.backend.Tests.Controllers
+{
+    public class NotificationsControllerTests
+    {
+        private readonly NotificationsController _controller;
+        private readonly Mock<INotificationsService> _serviceMock;
+
+        public NotificationsControllerTests()
+        {
+            _serviceMock = new Mock<INotificationsService>();
+            _controller = new NotificationsController(_serviceMock.Object);
+        }
+
+        [Fact]
+        public async Task GetEmailNotificationsByOrderId_ReturnsOk_WithServiceResult()
+        {
+            var response = new NotificationOrderResponseDto
+            {
+                OrderId = "order-123", SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = []
+            };
+            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId("order-123")).ReturnsAsync(response);
+
+            var result = await _controller.GetEmailNotificationsByOrderId("order-123");
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(response, okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetEmailNotificationsByOrderId_CallsService_WithCorrectOrderId()
+        {
+            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId("order-123"))
+                .ReturnsAsync(new NotificationOrderResponseDto
+                {
+                    OrderId = "order-123", SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = []
+                });
+
+            await _controller.GetEmailNotificationsByOrderId("order-123");
+
+            _serviceMock.Verify(s => s.GetEmailNotificationsByOrderId("order-123"), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetEmailNotificationsByOrderId_PropagatesException_WhenServiceThrows()
+        {
+            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(It.IsAny<string>()))
+                .ThrowsAsync(new Exception("Service failure"));
+
+            await Assert.ThrowsAsync<Exception>(() => _controller.GetEmailNotificationsByOrderId("order-123"));
+        }
+
+        [Fact]
+        public async Task GetSmsNotificationsByOrderId_ReturnsOk_WithServiceResult()
+        {
+            var response = new NotificationOrderResponseDto
+            {
+                OrderId = "order-456", SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = []
+            };
+            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId("order-456")).ReturnsAsync(response);
+
+            var result = await _controller.GetSmsNotificationsByOrderId("order-456");
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(response, okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetSmsNotificationsByOrderId_CallsService_WithCorrectOrderId()
+        {
+            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId("order-456"))
+                .ReturnsAsync(new NotificationOrderResponseDto
+                {
+                    OrderId = "order-456", SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = []
+                });
+
+            await _controller.GetSmsNotificationsByOrderId("order-456");
+
+            _serviceMock.Verify(s => s.GetSmsNotificationsByOrderId("order-456"), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSmsNotificationsByOrderId_PropagatesException_WhenServiceThrows()
+        {
+            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId(It.IsAny<string>()))
+                .ThrowsAsync(new Exception("Service failure"));
+
+            await Assert.ThrowsAsync<Exception>(() => _controller.GetSmsNotificationsByOrderId("order-456"));
+        }
+    }
+}

--- a/backend/test/altinn-support-dashboard.backend.Tests/Services/NotificationsServiceTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Services/NotificationsServiceTests.cs
@@ -1,0 +1,119 @@
+using altinn_support_dashboard.Server.Services;
+using altinn_support_dashboard.Server.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Text.Json;
+using Xunit;
+
+public class NotificationsServiceTests
+{
+    private readonly Mock<INotificationsClient> _clientMock;
+    private readonly NotificationsService _service;
+
+    private const string ValidOrderJson = """
+        {
+            "orderId": "order-123",
+            "sendersReference": "ref-abc",
+            "generated": 2,
+            "succeeded": 1,
+            "notifications": []
+        }
+        """;
+
+    public NotificationsServiceTests()
+    {
+        _clientMock = new Mock<INotificationsClient>();
+        var logger = Mock.Of<ILogger<INotificationsService>>();
+        _service = new NotificationsService(_clientMock.Object, logger);
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_ReturnsDeserializedResponse_WhenClientSucceeds()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+
+        var result = await _service.GetEmailNotificationsByOrderId("order-123");
+
+        Assert.Equal("order-123", result.OrderId);
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_DelegatesToClient_WithCorrectOrderId()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId("order-123")).ReturnsAsync(ValidOrderJson);
+
+        await _service.GetEmailNotificationsByOrderId("order-123");
+
+        _clientMock.Verify(c => c.GetEmailNotificationsByOrderId("order-123"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_ThrowsException_WhenClientThrows()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>()))
+            .ThrowsAsync(new Exception("API request failed"));
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetEmailNotificationsByOrderId("order-123"));
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_ThrowsJsonException_WhenResponseIsInvalidJson()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync("not-valid-json");
+
+        await Assert.ThrowsAsync<JsonException>(() => _service.GetEmailNotificationsByOrderId("order-123"));
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_ThrowsException_WhenResponseDeserializesToNull()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync("null");
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetEmailNotificationsByOrderId("order-123"));
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_ReturnsDeserializedResponse_WhenClientSucceeds()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+
+        var result = await _service.GetSmsNotificationsByOrderId("order-123");
+
+        Assert.Equal("order-123", result.OrderId);
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_DelegatesToClient_WithCorrectOrderId()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId("order-123")).ReturnsAsync(ValidOrderJson);
+
+        await _service.GetSmsNotificationsByOrderId("order-123");
+
+        _clientMock.Verify(c => c.GetSmsNotificationsByOrderId("order-123"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_ThrowsException_WhenClientThrows()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>()))
+            .ThrowsAsync(new Exception("API request failed"));
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetSmsNotificationsByOrderId("order-123"));
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_ThrowsJsonException_WhenResponseIsInvalidJson()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync("not-valid-json");
+
+        await Assert.ThrowsAsync<JsonException>(() => _service.GetSmsNotificationsByOrderId("order-123"));
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_ThrowsException_WhenResponseDeserializesToNull()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync("null");
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetSmsNotificationsByOrderId("order-123"));
+    }
+}

--- a/backend/test/altinn-support-dashboard.backend.Tests/Services/NotificationsServiceTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Services/NotificationsServiceTests.cs
@@ -116,4 +116,50 @@ public class NotificationsServiceTests
 
         await Assert.ThrowsAsync<Exception>(() => _service.GetSmsNotificationsByOrderId("order-123"));
     }
+
+    // --- GetAllNotificationsByOrderId ---
+
+    [Fact]
+    public async Task GetAllNotificationsByOrderId_ReturnsBothResults_WhenBothCallsSucceed()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+
+        var result = await _service.GetAllNotificationsByOrderId("order-123");
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllNotificationsByOrderId_ReturnsSingleResult_WhenEmailFails()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ThrowsAsync(new Exception("Email API failure"));
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+
+        var result = await _service.GetAllNotificationsByOrderId("order-123");
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task GetAllNotificationsByOrderId_ReturnsSingleResult_WhenSmsFails()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ThrowsAsync(new Exception("SMS API failure"));
+
+        var result = await _service.GetAllNotificationsByOrderId("order-123");
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task GetAllNotificationsByOrderId_ReturnsEmptyList_WhenBothCallsFail()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ThrowsAsync(new Exception("Email API failure"));
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ThrowsAsync(new Exception("SMS API failure"));
+
+        var result = await _service.GetAllNotificationsByOrderId("order-123");
+
+        Assert.Empty(result);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Add new NotificationsClient that calls the Altinn 3 Notifications API to    
  retrieve email and SMS notifications by order ID
  - Add NotificationsService with deserialization logic and a combined endpoint 
  (GetAllNotificationsByOrderId) that fetches both email and SMS notifications  
  in parallel, gracefully handling partial failures
  - Add NotificationsController with three endpoints: GET
  api/notifications/orderid/email/{orderId}, GET
  api/notifications/orderid/sms/{orderId}, and GET
  api/notifications/orderid/{orderId}
  - Add DTO models for notification responses (NotificationOrderResponseDto,    
  NotificationDto, NotificationRecipientDto, NotificationSendStatusDto)
  - Add unit tests for both the controller and service layers


