### PR TITLE
673 frontend notifications page

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/app/App.tsx
+++ b/frontend/altinn-support-dashboard.client/src/app/App.tsx
@@ -16,6 +16,7 @@ import { ManualRoleSearchPage } from "../pages/ManualRoleSearchPage";
 import NewOrganizationPage from "../pages/NewOrganizationPage";
 import SettingsPage from "../pages/SettingsPage";
 import { CorrespondencePage } from "../pages/CorrespondencePage";
+import { NotificationPage } from "../pages/NotificationPage";
 import { useAppStore } from "../stores/Appstore";
 import PrivateRoutes from "./PrivateRoutes";
 import { ToastContainer } from "react-toastify";
@@ -72,6 +73,10 @@ const App: React.FC = () => {
                 <Route
                   path="/correspondence"
                   element={<CorrespondencePage />}
+                />
+                <Route
+                  path="/notification"
+                  element={<NotificationPage />}
                 />
                 <Route path="/signout" element={<SignOutPage />} />
               </Route>

--- a/frontend/altinn-support-dashboard.client/src/components/Correspondence/CorrespondenceButton.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Correspondence/CorrespondenceButton.tsx
@@ -55,6 +55,8 @@ const CorrespondenceButton: React.FC<CorrespondenceButtonProps> = ({
         notificationChannel: notificationChannel,
       };
     }
+    console.log("Notification channel:", notificationChannel);
+    console.log("Full request:", JSON.stringify(correspondence, null, 2));
     const response = await post.mutateAsync(correspondence);
     setResponseMessage(response);
     sessionStorage.setItem("responseMessage", JSON.stringify(response));

--- a/frontend/altinn-support-dashboard.client/src/components/Correspondence/CorrespondenceButton.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Correspondence/CorrespondenceButton.tsx
@@ -55,8 +55,6 @@ const CorrespondenceButton: React.FC<CorrespondenceButtonProps> = ({
         notificationChannel: notificationChannel,
       };
     }
-    console.log("Notification channel:", notificationChannel);
-    console.log("Full request:", JSON.stringify(correspondence, null, 2));
     const response = await post.mutateAsync(correspondence);
     setResponseMessage(response);
     sessionStorage.setItem("responseMessage", JSON.stringify(response));

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationCard.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationCard.tsx
@@ -1,29 +1,32 @@
+import React from 'react';
 import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
-import { NotificationOrderResponse } from "../../models/notificationModels"
+import { NotificationOrderResponse } from "../../models/notificationModels";
+import NotificationList from './NotificationList';
+import style from "./styles/NotificationCard.module.css";
 
 
-
-type NotificationOrderSummaryProps = {
+type NotificationCardProps = {
     order: NotificationOrderResponse;
 }
 
-const NotificationOrderSummary: React.FC<NotificationOrderSummaryProps> = ({ order }) => {
+
+const NotificationCard: React.FC<NotificationCardProps> = ({ order }) => {
     const getType = () => {
         const first = order.notifications?.[0];
         if (!first) return "Ordredetaljer";
         return first.recipient?.emailAddress ? "E-post" : "SMS";
-    }
+    };
+
     return (
-        <Card data-color="neutral">
-            <Heading level={2} data-size="xs">
-                {getType()} 
-            </Heading>
+        <Card data-color="neutral" className={style.card}>
+            <Heading level={2} data-size="xs">{getType()}</Heading>
             <Paragraph>Order id: {order.orderId}</Paragraph>
             <Paragraph>Avsenders referanse: {order.sendersReference}</Paragraph>
             <Paragraph>Generert: {order.generated}</Paragraph>
             <Paragraph>Vellykket: {order.succeeded}</Paragraph>
+            <NotificationList notifications={order.notifications || []} />
         </Card>
-    );
-};
+    )
+}
 
-export default NotificationOrderSummary;
+export default NotificationCard;

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
@@ -1,7 +1,7 @@
 import { Card, Table } from "@digdir/designsystemet-react";
 import NotificationStatusCode from "./NotificationStatusCode";
 import { NotificationItem } from "../../models/notificationModels";
-
+import style from "./styles/NotificationList.module.css";
 
 
 
@@ -15,9 +15,9 @@ const NotificationList: React.FC<NotificationListProps> = ({ notifications }) =>
             <Table data-size="sm" data-color="neutral" border>
                 <Table.Head>
                     <Table.Row>
-                        <Table.HeaderCell>Mottaker</Table.HeaderCell>
-                        <Table.HeaderCell>Type</Table.HeaderCell>
-                        <Table.HeaderCell>Status</Table.HeaderCell>
+                        <Table.HeaderCell className={style.mottakerCell}>Mottaker</Table.HeaderCell>
+                        <Table.HeaderCell className={style.typeCell}>Type</Table.HeaderCell>
+                        <Table.HeaderCell className={style.statusCell}>Status</Table.HeaderCell>
                     </Table.Row>
                 </Table.Head>
                 <Table.Body>

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
@@ -15,7 +15,7 @@ const NotificationList: React.FC<NotificationListProps> = ({ notifications }) =>
 
     const filteredNotifications = notifications.filter(n => n.id.includes(searchId));
     return (
-        <Card data-color="neutral">
+        <Card data-color="neutral" className={style.card}>
             <Textfield
                 label=""
                 placeholder="Skriv inn notifikasjons id"

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
@@ -18,6 +18,7 @@ const NotificationList: React.FC<NotificationListProps> = ({ notifications }) =>
                         <Table.HeaderCell className={style.mottakerCell}>Mottaker</Table.HeaderCell>
                         <Table.HeaderCell className={style.typeCell}>Type</Table.HeaderCell>
                         <Table.HeaderCell className={style.statusCell}>Status</Table.HeaderCell>
+                        <Table.HeaderCell className={style.notifIdCell}>Notifikasjons id</Table.HeaderCell>
                     </Table.Row>
                 </Table.Head>
                 <Table.Body>
@@ -32,6 +33,7 @@ const NotificationList: React.FC<NotificationListProps> = ({ notifications }) =>
                             <Table.Cell>
                                 <NotificationStatusCode notification={n} />
                             </Table.Cell>
+                            <Table.Cell>{n.id}</Table.Cell>
                         </Table.Row>
                     ))}
                 </Table.Body>

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
@@ -23,7 +23,7 @@ const NotificationList: React.FC<NotificationListProps> = ({ notifications }) =>
                 </Table.Head>
                 <Table.Body>
                     {notifications.map((n) => (
-                        <Table.Row key={n.id}>
+                        <Table.Row key={n.id} className={style.row}>
                             <Table.Cell>
                                 {n.recipient?.emailAddress || n.recipient?.mobileNumber}
                             </Table.Cell>

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
@@ -1,0 +1,43 @@
+import { Card, Table } from "@digdir/designsystemet-react";
+import NotificationStatusCode from "./NotificationStatusCode";
+import { NotificationItem } from "../../models/notificationModels";
+
+
+
+
+type NotificationListProps = {
+    notifications: NotificationItem[];
+};
+
+const NotificationList: React.FC<NotificationListProps> = ({ notifications }) => {
+    return (
+        <Card data-color="neutral">
+            <Table data-size="sm" data-color="neutral" border>
+                <Table.Head>
+                    <Table.Row>
+                        <Table.HeaderCell>Mottaker</Table.HeaderCell>
+                        <Table.HeaderCell>Type</Table.HeaderCell>
+                        <Table.HeaderCell>Status</Table.HeaderCell>
+                    </Table.Row>
+                </Table.Head>
+                <Table.Body>
+                    {notifications.map((n) => (
+                        <Table.Row key={n.id}>
+                            <Table.Cell>
+                                {n.recipient?.emailAddress || n.recipient?.mobileNumber}
+                            </Table.Cell>
+                            <Table.Cell>
+                                {n.recipient?.emailAddress ? "E-post" : "SMS"}
+                            </Table.Cell>
+                            <Table.Cell>
+                                <NotificationStatusCode notification={n} />
+                            </Table.Cell>
+                        </Table.Row>
+                    ))}
+                </Table.Body>
+            </Table>
+        </Card>
+    );
+};
+
+export default NotificationList;

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
@@ -1,7 +1,8 @@
-import { Card, Table } from "@digdir/designsystemet-react";
+import { Card, Table, Textfield } from "@digdir/designsystemet-react";
 import NotificationStatusCode from "./NotificationStatusCode";
 import { NotificationItem } from "../../models/notificationModels";
 import style from "./styles/NotificationList.module.css";
+import { useState } from "react";
 
 
 
@@ -10,8 +11,18 @@ type NotificationListProps = {
 };
 
 const NotificationList: React.FC<NotificationListProps> = ({ notifications }) => {
+    const [searchId, setSearchId] = useState("");
+
+    const filteredNotifications = notifications.filter(n => n.id.includes(searchId));
     return (
         <Card data-color="neutral">
+            <Textfield
+                label=""
+                placeholder="Skriv inn notifikasjons id"
+                value={searchId}
+                onChange={(e) => setSearchId(e.target.value)}
+                className={style.searchField}
+            />
             <Table data-size="sm" data-color="neutral" border>
                 <Table.Head>
                     <Table.Row>
@@ -22,7 +33,7 @@ const NotificationList: React.FC<NotificationListProps> = ({ notifications }) =>
                     </Table.Row>
                 </Table.Head>
                 <Table.Body>
-                    {notifications.map((n) => (
+                    {filteredNotifications.map((n) => (
                         <Table.Row key={n.id} className={style.row}>
                             <Table.Cell>
                                 {n.recipient?.emailAddress || n.recipient?.mobileNumber}

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationList.tsx
@@ -1,4 +1,4 @@
-import { Card, Table, Textfield } from "@digdir/designsystemet-react";
+import {Table, Textfield } from "@digdir/designsystemet-react";
 import NotificationStatusCode from "./NotificationStatusCode";
 import { NotificationItem } from "../../models/notificationModels";
 import style from "./styles/NotificationList.module.css";
@@ -15,7 +15,7 @@ const NotificationList: React.FC<NotificationListProps> = ({ notifications }) =>
 
     const filteredNotifications = notifications.filter(n => n.id.includes(searchId));
     return (
-        <Card data-color="neutral" className={style.card}>
+        <>
             <Textfield
                 label=""
                 placeholder="Skriv inn notifikasjons id"
@@ -49,7 +49,7 @@ const NotificationList: React.FC<NotificationListProps> = ({ notifications }) =>
                     ))}
                 </Table.Body>
             </Table>
-        </Card>
+        </>
     );
 };
 

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationOrderSummary.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationOrderSummary.tsx
@@ -8,10 +8,15 @@ type NotificationOrderSummaryProps = {
 }
 
 const NotificationOrderSummary: React.FC<NotificationOrderSummaryProps> = ({ order }) => {
+    const getType = () => {
+        const first = order.notifications?.[0];
+        if (!first) return "Ordredetaljer";
+        return first.recipient?.emailAddress ? "E-post" : "SMS";
+    }
     return (
         <Card data-color="neutral">
             <Heading level={2} data-size="xs">
-                Ordedetaljer
+                {getType()} 
             </Heading>
             <Paragraph>Order id: {order.orderId}</Paragraph>
             <Paragraph>Avsenders referanse: {order.sendersReference}</Paragraph>

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationOrderSummary.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationOrderSummary.tsx
@@ -1,0 +1,24 @@
+import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
+import { NotificationOrderResponse } from "../../models/notificationModels"
+
+
+
+type NotificationOrderSummaryProps = {
+    order: NotificationOrderResponse;
+}
+
+const NotificationOrderSummary: React.FC<NotificationOrderSummaryProps> = ({ order }) => {
+    return (
+        <Card data-color="neutral">
+            <Heading level={2} data-size="xs">
+                Ordedetaljer
+            </Heading>
+            <Paragraph>Order id: {order.orderId}</Paragraph>
+            <Paragraph>Avsenders referanse: {order.sendersReference}</Paragraph>
+            <Paragraph>Generert: {order.generated}</Paragraph>
+            <Paragraph>Vellykket: {order.succeeded}</Paragraph>
+        </Card>
+    );
+};
+
+export default NotificationOrderSummary;

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationSearchBar.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationSearchBar.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { Button, Search, Textfield } from '@digdir/designsystemet-react';
+
+type NotificationSearchBarProps = {
+    orderId: string;
+    setOrderId: (value: string) => void;
+}
+
+
+const NotificationSearchBar: React.FC<NotificationSearchBarProps> = ({
+    orderId,
+    setOrderId,
+}) => {
+    const [inputValue, setInputValue] = useState(orderId ?? "");
+
+    const handleSearch = () => {
+        setOrderId(inputValue);
+    }
+
+    return (
+        <div>
+            <Textfield
+                label="Order ID"
+                placeholder="Skriv inn ordre-id"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                        handleSearch();
+                    }
+                }}
+            />
+            <Button
+                onClick={() => {
+                    setInputValue("")
+                    setOrderId("")
+                }}
+            >
+                x
+            </Button>
+            <Button
+                onClick={handleSearch}
+                variant="tertiary"
+            >
+                <Search/>
+            </Button>
+        </div>
+    )
+}
+
+export default NotificationSearchBar;

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationSearchBar.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationSearchBar.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Button, Search, Textfield } from '@digdir/designsystemet-react';
+import style from './styles/NotificationSearchBar.module.css';
 
 type NotificationSearchBarProps = {
     orderId: string;
@@ -18,7 +19,7 @@ const NotificationSearchBar: React.FC<NotificationSearchBarProps> = ({
     }
 
     return (
-        <div>
+        <div className={style.container}>
             <Textfield
                 label="Order ID"
                 placeholder="Skriv inn ordre-id"
@@ -29,20 +30,23 @@ const NotificationSearchBar: React.FC<NotificationSearchBarProps> = ({
                         handleSearch();
                     }
                 }}
+                className = {style.textfield}
             />
+            <Button
+                onClick={handleSearch}
+                variant="secondary"
+                className={style.searchButton}
+            >
+                <Search/>
+            </Button>
             <Button
                 onClick={() => {
                     setInputValue("")
                     setOrderId("")
                 }}
+                className={style.removeButton}
             >
                 x
-            </Button>
-            <Button
-                onClick={handleSearch}
-                variant="tertiary"
-            >
-                <Search/>
             </Button>
         </div>
     )

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationStatusCode.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationStatusCode.tsx
@@ -1,0 +1,20 @@
+import { Alert } from "@digdir/designsystemet-react";
+import { NotificationItem } from "../../models/notificationModels";
+
+
+
+type NotificationStatusCodeProps = {
+    notification: NotificationItem;
+}
+
+const NotificationStatusCode: React.FC<NotificationStatusCodeProps> = ({ notification }) => {
+    const color = notification.succeeded ? "success" : "danger";
+
+    return (
+        <Alert data-color={color} data-size="sm">
+            {notification.sendStatus?.status} - {notification.sendStatus?.description}
+        </Alert>
+    );
+};
+
+export default NotificationStatusCode;

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationStatusCode.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationStatusCode.tsx
@@ -8,10 +8,21 @@ type NotificationStatusCodeProps = {
 }
 
 const NotificationStatusCode: React.FC<NotificationStatusCodeProps> = ({ notification }) => {
-    const color = notification.succeeded ? "success" : "danger";
+    const getColor = (status: string) => {
+        switch (status?.toLowerCase()) {
+            case "delivered":
+                return "success";
+            case "failed":
+                return "danger";
+            case "new":
+                return "warning";
+            default:
+                return "info";
+        }
+    };
 
     return (
-        <Alert data-color={color} data-size="sm">
+        <Alert data-color={getColor(notification.sendStatus?.status)} data-size="sm">
             {notification.sendStatus?.status} - {notification.sendStatus?.description}
         </Alert>
     );

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationStatusCode.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationStatusCode.tsx
@@ -7,19 +7,40 @@ type NotificationStatusCodeProps = {
     notification: NotificationItem;
 }
 
+const colorMap: Record<string, "success" | "danger" | "warning" | "info"> = {
+    registered: "info",
+    processing: "info",
+    completed: "success",
+    sendconditionnotmet: "danger",
+    cancelled: "danger",
+    processed: "warning",
+    new: "info",
+    sending: "info",
+    accepted: "warning",
+    delivered: "success",
+    failed: "danger",
+    failed_invalidrecipient: "danger",
+    failed_recipientreserved: "danger",
+    failed_barredreceiver: "danger",
+    failed_deletedreceiver: "danger",
+    failed_expired: "danger",
+    failed_undelivered: "danger",
+    failed_recipientnotidentified: "danger",
+    failed_rejected: "danger",
+    succeeded: "success",
+    failed_invalidformat: "danger",
+    failed_suppressedrecipient: "danger",
+    failed_transienterror: "danger",
+    failed_bounced: "danger",
+    failed_filterspam: "danger",
+    failed_quarantined: "danger",
+    failed_ttl: "danger",
+
+}
+
+const getColor = (status: string) => colorMap[status.toLowerCase()] || "danger";
+
 const NotificationStatusCode: React.FC<NotificationStatusCodeProps> = ({ notification }) => {
-    const getColor = (status: string) => {
-        switch (status?.toLowerCase()) {
-            case "delivered":
-                return "success";
-            case "failed":
-                return "danger";
-            case "new":
-                return "warning";
-            default:
-                return "info";
-        }
-    };
 
     return (
         <Alert data-color={getColor(notification.sendStatus?.status)} data-size="sm" className={style.alert}>

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationStatusCode.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationStatusCode.tsx
@@ -1,6 +1,6 @@
 import { Alert } from "@digdir/designsystemet-react";
 import { NotificationItem } from "../../models/notificationModels";
-
+import style from "./styles/NotificationsStatusCode.module.css";
 
 
 type NotificationStatusCodeProps = {
@@ -22,7 +22,7 @@ const NotificationStatusCode: React.FC<NotificationStatusCodeProps> = ({ notific
     };
 
     return (
-        <Alert data-color={getColor(notification.sendStatus?.status)} data-size="sm">
+        <Alert data-color={getColor(notification.sendStatus?.status)} data-size="sm" className={style.alert}>
             {notification.sendStatus?.status} - {notification.sendStatus?.description}
         </Alert>
     );

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationCard.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationCard.module.css
@@ -1,0 +1,5 @@
+.card{
+    height: 100%;
+    overflow-y: auto;
+    margin-bottom: 1rem;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
@@ -1,0 +1,12 @@
+.typeCell{
+    width: 5rem;
+}
+
+.statusCell{
+    min-width: 20rem;
+    overflow-y: auto;
+}
+
+.mottakerCell{
+    width: 20rem;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
@@ -14,3 +14,7 @@
 .notifIdCell{
     min-width: 25rem;
 }
+
+.row{
+    height: 3rem;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
@@ -29,3 +29,8 @@
 .searchField :focus {
     outline: none;
 }
+
+.card{
+    height: 100%;
+    overflow-y: auto;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
@@ -21,6 +21,7 @@
 
 .searchField{
     margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
 }
 
 .searchField :hover {

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
@@ -10,3 +10,7 @@
 .mottakerCell{
     width: 20rem;
 }
+
+.notifIdCell{
+    min-width: 25rem;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationList.module.css
@@ -18,3 +18,14 @@
 .row{
     height: 3rem;
 }
+
+.searchField{
+    margin-bottom: 0.5rem;
+}
+
+.searchField :hover {
+    outline: none;
+}
+.searchField :focus {
+    outline: none;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationSearchBar.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationSearchBar.module.css
@@ -1,0 +1,24 @@
+.container{
+    display: flex;
+    flex-direction: row;
+    gap: 1.5rem;
+    padding-bottom: 1rem;
+}
+
+.textfield{
+    width: 50%;
+}
+
+.removeButton{
+    height: 2.5rem;
+    align-self: flex-end;
+}
+
+.searchButton{
+    height: 2.5rem;
+    align-self: flex-end;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationsStatusCode.module.css
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/styles/NotificationsStatusCode.module.css
@@ -1,0 +1,6 @@
+.alert{
+    height: 5rem;
+    overflow-y: auto;
+    padding: 0rem 2rem;
+    font-size: medium;
+}

--- a/frontend/altinn-support-dashboard.client/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   MagnifyingGlassIcon,
   CogIcon,
   EnvelopeOpenIcon,
+  DatabaseIcon,
 } from "@navikt/aksel-icons";
 
 // design system imports
@@ -96,6 +97,12 @@ const Sidebar: React.FC = () => {
               to="/correspondence"
               title="Melding"
               icon={<EnvelopeOpenIcon className={classes.icons} />}
+              isCollapsed={isCollapsed}
+            />
+            <NavItem
+              to="/notification"
+              title="Varsling"
+              icon ={<DatabaseIcon className={classes.icons} />}
               isCollapsed={isCollapsed}
             />
             <NavItem

--- a/frontend/altinn-support-dashboard.client/src/hooks/hooks.ts
+++ b/frontend/altinn-support-dashboard.client/src/hooks/hooks.ts
@@ -10,6 +10,7 @@ import { useMutation, useQuery, UseQueryResult } from "@tanstack/react-query";
 import {
   fetchERoles,
   fetchNotificationAddresses,
+  fetchNotificationByOrderId,
   fetchOfficialContacts,
   fetchOrganizations,
   fetchPersonalContacts,
@@ -153,3 +154,15 @@ export const useCorrespondencePost = () => {
     },
   });
 };
+
+export function useNotifications(orderId: string) {
+    const notificationQuery = useQuery({
+        queryKey: ["notifications", orderId],
+        queryFn: () => fetchNotificationByOrderId(orderId),
+        enabled: !!orderId,
+        retry: false,
+        staleTime: 2 * 60 * 1000,
+        refetchOnWindowFocus: false,
+    });
+    return notificationQuery;
+}

--- a/frontend/altinn-support-dashboard.client/src/models/notificationModels.ts
+++ b/frontend/altinn-support-dashboard.client/src/models/notificationModels.ts
@@ -1,0 +1,26 @@
+export interface NotificationOrderResponse {
+    orderId: string;
+    sendersReference: string;
+    generated: number;
+    succeeded: number;
+    notifications: NotificationItem[];
+}
+
+export interface NotificationItem {
+    id: string;
+    succeeded: boolean;
+    recipient: NotificationRecipient;
+    sendStatus: NotificationSendStatus;
+}
+
+export interface NotificationRecipient {
+    emailAddress?: string;
+    mobileNumber?: string;
+    orgamnizationNumber?: string;
+}
+
+export interface NotificationSendStatus {
+    status: string;
+    description: string;
+    lastUpdate: string;
+}

--- a/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
@@ -2,8 +2,7 @@ import { Heading } from '@digdir/designsystemet-react';
 import { useState } from 'react';
 import NotificationSearchBar from '../components/Notification/NotificationSearchBar';
 import { useNotifications } from '../hooks/hooks';
-import NotificationOrderSummary from '../components/Notification/NotificationOrderSummary';
-import NotificationList from '../components/Notification/NotificationList';
+import NotificationCard from '../components/Notification/NotificationCard';
 import style from './styles/NotificationPage.module.css';
 
 
@@ -24,8 +23,7 @@ export const NotificationPage = () => {
             {/* Filters out the notifications with 0 (shows only email if sms was 0 f.ex.) */}
             {notificationQuery.data?.filter(o => o.notifications.length > 0).map((order, index) => (
                 <div key={index}>
-                    <NotificationOrderSummary order={order} />
-                    <NotificationList notifications={order.notifications || []} />
+                    <NotificationCard key={index} order={order}/>
                 </div>
             ))}
         </div>

--- a/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
@@ -4,6 +4,7 @@ import NotificationSearchBar from '../components/Notification/NotificationSearch
 import { useNotifications } from '../hooks/hooks';
 import NotificationOrderSummary from '../components/Notification/NotificationOrderSummary';
 import NotificationList from '../components/Notification/NotificationList';
+import style from './styles/NotificationPage.module.css';
 
 
 
@@ -11,20 +12,25 @@ import NotificationList from '../components/Notification/NotificationList';
 export const NotificationPage = () => {
     const [orderId, setOrderId] = useState("");
     const notificationQuery  = useNotifications(orderId);
+
+    console.log("orderId:", orderId);
+console.log("query status:", notificationQuery.status);
+console.log("query data:", notificationQuery.data);
+console.log("query error:", notificationQuery.error);
     return (
         <div>
-            <Heading level={1} data-size="sm">
+            <Heading level={1} data-size="sm" className={style.heading}>
                 Søk etter varsling
             </Heading>
 
             <NotificationSearchBar orderId={orderId} setOrderId={setOrderId} />
 
-            {notificationQuery.data && (
-                <>
-                    <NotificationOrderSummary order={notificationQuery.data} />
-                    <NotificationList notifications={notificationQuery.data.notifications || []} />
-                </>
-            )}
+            {notificationQuery.data &&  notificationQuery.data.map((order, index) => (
+                <div key={index}>
+                    <NotificationOrderSummary order={order} />
+                    <NotificationList notifications={order.notifications || []} />
+                </div>
+            ))}
         </div>
     )
 }

--- a/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
@@ -14,7 +14,7 @@ export const NotificationPage = () => {
     const notificationQuery  = useNotifications(orderId);
     
     return (
-        <div>
+        <div className={style.container}>
             <Heading level={1} data-size="sm" className={style.heading}>
                 Søk etter varsling
             </Heading>

--- a/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
@@ -1,14 +1,30 @@
 import { Heading } from '@digdir/designsystemet-react';
+import { useState } from 'react';
+import NotificationSearchBar from '../components/Notification/NotificationSearchBar';
+import { useNotifications } from '../hooks/hooks';
+import NotificationOrderSummary from '../components/Notification/NotificationOrderSummary';
+import NotificationList from '../components/Notification/NotificationList';
 
 
 
 
 export const NotificationPage = () => {
+    const [orderId, setOrderId] = useState("");
+    const notificationQuery  = useNotifications(orderId);
     return (
         <div>
             <Heading level={1} data-size="sm">
                 Søk etter varsling
             </Heading>
+
+            <NotificationSearchBar orderId={orderId} setOrderId={setOrderId} />
+
+            {notificationQuery.data && (
+                <>
+                    <NotificationOrderSummary order={notificationQuery.data} />
+                    <NotificationList notifications={notificationQuery.data.notifications || []} />
+                </>
+            )}
         </div>
     )
 }

--- a/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
@@ -12,11 +12,7 @@ import style from './styles/NotificationPage.module.css';
 export const NotificationPage = () => {
     const [orderId, setOrderId] = useState("");
     const notificationQuery  = useNotifications(orderId);
-
-    console.log("orderId:", orderId);
-console.log("query status:", notificationQuery.status);
-console.log("query data:", notificationQuery.data);
-console.log("query error:", notificationQuery.error);
+    
     return (
         <div>
             <Heading level={1} data-size="sm" className={style.heading}>
@@ -25,7 +21,8 @@ console.log("query error:", notificationQuery.error);
 
             <NotificationSearchBar orderId={orderId} setOrderId={setOrderId} />
 
-            {notificationQuery.data &&  notificationQuery.data.map((order, index) => (
+            {/* Filters out the notifications with 0 (shows only email if sms was 0 f.ex.) */}
+            {notificationQuery.data?.filter(o => o.notifications.length > 0).map((order, index) => (
                 <div key={index}>
                     <NotificationOrderSummary order={order} />
                     <NotificationList notifications={order.notifications || []} />

--- a/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
@@ -1,0 +1,14 @@
+import { Heading } from '@digdir/designsystemet-react';
+
+
+
+
+export const NotificationPage = () => {
+    return (
+        <div>
+            <Heading level={1} data-size="sm">
+                Søk etter varsling
+            </Heading>
+        </div>
+    )
+}

--- a/frontend/altinn-support-dashboard.client/src/pages/styles/NotificationPage.module.css
+++ b/frontend/altinn-support-dashboard.client/src/pages/styles/NotificationPage.module.css
@@ -1,0 +1,3 @@
+.heading {
+  margin-bottom: 1rem;
+}

--- a/frontend/altinn-support-dashboard.client/src/pages/styles/NotificationPage.module.css
+++ b/frontend/altinn-support-dashboard.client/src/pages/styles/NotificationPage.module.css
@@ -1,3 +1,9 @@
 .heading {
   margin-bottom: 1rem;
 }
+
+.container {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}

--- a/frontend/altinn-support-dashboard.client/src/setupTests.ts
+++ b/frontend/altinn-support-dashboard.client/src/setupTests.ts
@@ -18,3 +18,10 @@ if (!HTMLElement.prototype.showPopover) {
 if (!HTMLElement.prototype.hidePopover) {
   HTMLElement.prototype.hidePopover = () => {};
 }
+
+if (typeof globalThis.requestAnimationFrame === 'undefined') {
+  globalThis.requestAnimationFrame = (callback) => setTimeout(callback, 0) as unknown as number;
+}
+if (typeof globalThis.cancelAnimationFrame === 'undefined') {
+  globalThis.cancelAnimationFrame = (id) => clearTimeout(id);
+}

--- a/frontend/altinn-support-dashboard.client/src/utils/api.ts
+++ b/frontend/altinn-support-dashboard.client/src/utils/api.ts
@@ -135,9 +135,9 @@ export const fetchNotificationAddresses = async (
 
 export const fetchNotificationByOrderId = async (
   orderId: string,
-):Promise<NotificationOrderResponse | null> => {
+):Promise<NotificationOrderResponse[] | null> => {
   const res = await authorizedFetch(
-    `/api/notifications/orderId/${encodeURIComponent(orderId)}`,
+    `/api/notifications/orderid/${encodeURIComponent(orderId)}`,
   );
 
   if (res.status === 404) return null;

--- a/frontend/altinn-support-dashboard.client/src/utils/api.ts
+++ b/frontend/altinn-support-dashboard.client/src/utils/api.ts
@@ -5,6 +5,7 @@ import {
   PersonalContactAltinn3,
 } from "../models/models";
 import { RolesAndRights, RolesAndRightsRequest } from "../models/rolesModels";
+import { NotificationOrderResponse } from "../models/notificationModels";
 
 //this file defines which which api endpoints we want to fetch data from
 
@@ -130,4 +131,20 @@ export const fetchNotificationAddresses = async (
 
   const data = await res.json();
   return Array.isArray(data) ? data : [data];
+};
+
+export const fetchNotificationByOrderId = async (
+  orderId: string,
+):Promise<NotificationOrderResponse | null> => {
+  const res = await authorizedFetch(
+    `/api/notifications/orderId/${encodeURIComponent(orderId)}`,
+  );
+
+  if (res.status === 404) return null;
+  if(!res.ok)
+    throw new Error(
+      (await res.text()) || "Error fetching notification by orderId",
+    )
+
+  return await res.json();
 };

--- a/frontend/altinn-support-dashboard.client/test/Notifications/NotificationCard.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Notifications/NotificationCard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { NotificationOrderResponse } from "../../src/models/notificationModels";
 import { render, screen } from "@testing-library/react";
-import NotificationOrderSummary from "../../src/components/Notification/NotificationOrderSummary";
+import NotificationCard from "../../src/components/Notification/NotificationCard";
 import "@testing-library/jest-dom/vitest";
 
 
@@ -16,7 +16,7 @@ describe("NotificationOrderSummary", () => {
     };
 
     it("should render order details", () => {
-        render(<NotificationOrderSummary order={baseOrder} />);
+        render(<NotificationCard order={baseOrder} />);
 
         expect(screen.getByText("Order id: abc-123")).toBeInTheDocument();
         expect(screen.getByText("Avsenders referanse: ref-456")).toBeInTheDocument();
@@ -25,7 +25,7 @@ describe("NotificationOrderSummary", () => {
     });
 
     it("should show 'Ordredetaljer' when there are no notifications", () => {
-        render(<NotificationOrderSummary order={baseOrder} />);
+        render(<NotificationCard order={baseOrder} />);
 
         expect(screen.getByText("Ordredetaljer")).toBeInTheDocument();
     });
@@ -43,9 +43,9 @@ describe("NotificationOrderSummary", () => {
             ],
         };
 
-        render(<NotificationOrderSummary order={emailOrder} />);
+        render(<NotificationCard order={emailOrder} />);
 
-        expect(screen.getByText("E-post")).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "E-post" })).toBeInTheDocument();
     });
 
     it("should show 'SMS' when the first notification is an SMS", () => {
@@ -61,8 +61,8 @@ describe("NotificationOrderSummary", () => {
             ],
         };
 
-        render(<NotificationOrderSummary order={smsOrder} />);
+        render(<NotificationCard order={smsOrder} />);
 
-        expect(screen.getByText("SMS")).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "SMS" })).toBeInTheDocument();
     });
 })

--- a/frontend/altinn-support-dashboard.client/test/Notifications/NotificationList.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Notifications/NotificationList.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
+import NotificationList from "../../src/components/Notification/NotificationList";
+import { NotificationItem } from "../../src/models/notificationModels";
+
+
+const emailNotification: NotificationItem = {
+    id: "notif-1",
+    succeeded: true,
+    recipient: { emailAddress: "test@test.no"},
+    sendStatus: { status: "Delivered", description: "Delivered successfully", lastUpdate: "2026-01-01T00:00:00Z" },
+};
+
+const smsNotification: NotificationItem = {
+    id: "notif-2",
+    succeeded: false,
+    recipient: { mobileNumber: "12345678"},
+    sendStatus: { status: "Failed", description: "Failed to deliver", lastUpdate: "2026-01-01T00:00:00Z" },
+};
+
+describe("NotificationList", () => {
+    it("should render table headers", () => {
+        render(<NotificationList notifications={[]} />);
+
+        expect(screen.getByText("Mottaker")).toBeInTheDocument();
+        expect(screen.getByText("Type")).toBeInTheDocument();
+        expect(screen.getByText("Status")).toBeInTheDocument();
+        expect(screen.getByText("Notifikasjons id")).toBeInTheDocument();
+    });
+
+    it("should render email notifications row", () => {
+        render(<NotificationList notifications={[emailNotification]} />);
+
+        expect(screen.getByText("test@test.no")).toBeInTheDocument();
+        expect(screen.getByText("E-post")).toBeInTheDocument();
+        expect(screen.getByText("Delivered - Delivered successfully")).toBeInTheDocument();
+        expect(screen.getByText("notif-1")).toBeInTheDocument();
+    });
+
+    it("should render SMS notifications row", () => {
+        render(<NotificationList notifications={[smsNotification]} />);
+
+        expect(screen.getByText("12345678")).toBeInTheDocument();
+        expect(screen.getByText("SMS")).toBeInTheDocument();
+        expect(screen.getByText("Failed - Failed to deliver")).toBeInTheDocument();
+        expect(screen.getByText("notif-2")).toBeInTheDocument();
+    });
+
+    it("should render multiple notifications", () => {
+        render(<NotificationList notifications={[emailNotification, smsNotification]} />);
+
+        expect(screen.getByText("test@test.no")).toBeInTheDocument();
+        expect(screen.getByText("12345678")).toBeInTheDocument();
+    });
+
+    it("should filter notifications by id", async () => {
+        render(<NotificationList notifications={[emailNotification, smsNotification]} />);
+        const user = userEvent.setup();
+
+        const searchInput = screen.getByPlaceholderText("Skriv inn notifikasjons id");
+        await user.type(searchInput, "notif-1");
+
+        expect(screen.getByText("test@test.no")).toBeInTheDocument();
+        expect(screen.queryByText("12345678")).not.toBeInTheDocument();
+    });
+
+    it("should show all notifications when search is cleared", async () => {
+        render(<NotificationList notifications={[emailNotification, smsNotification]} />);
+        const user = userEvent.setup();
+        const searchInput = screen.getByPlaceholderText("Skriv inn notifikasjons id");
+
+        await user.type(searchInput, "notif-1");
+        expect(screen.queryByText("12345678")).not.toBeInTheDocument();
+
+        await user.clear(searchInput);
+        expect(screen.getByText("12345678")).toBeInTheDocument();
+    });
+
+    it("should show no rows if search matches nothing", async () => {
+        render(<NotificationList notifications={[emailNotification, smsNotification]} />);
+        const user = userEvent.setup();
+        const searchInput = screen.getByPlaceholderText("Skriv inn notifikasjons id");
+
+        await user.type(searchInput, "non-existent-id");
+
+        expect(screen.queryByText("test@test.no")).not.toBeInTheDocument();
+        expect(screen.queryByText("12345678")).not.toBeInTheDocument();
+    });
+})

--- a/frontend/altinn-support-dashboard.client/test/Notifications/NotificationOrderSummary.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Notifications/NotificationOrderSummary.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { NotificationOrderResponse } from "../../src/models/notificationModels";
+import { render, screen } from "@testing-library/react";
+import NotificationOrderSummary from "../../src/components/Notification/NotificationOrderSummary";
+import "@testing-library/jest-dom/vitest";
+
+
+
+describe("NotificationOrderSummary", () => {
+    const baseOrder: NotificationOrderResponse = {
+        orderId: "abc-123",
+        sendersReference: "ref-456",
+        generated: 3,
+        succeeded: 2,
+        notifications: [],
+    };
+
+    it("should render order details", () => {
+        render(<NotificationOrderSummary order={baseOrder} />);
+
+        expect(screen.getByText("Order id: abc-123")).toBeInTheDocument();
+        expect(screen.getByText("Avsenders referanse: ref-456")).toBeInTheDocument();
+        expect(screen.getByText("Generert: 3")).toBeInTheDocument();
+        expect(screen.getByText("Vellykket: 2")).toBeInTheDocument();
+    });
+
+    it("should show 'Ordredetaljer' when there are no notifications", () => {
+        render(<NotificationOrderSummary order={baseOrder} />);
+
+        expect(screen.getByText("Ordredetaljer")).toBeInTheDocument();
+    });
+
+    it("should show 'E-post when the first notification is an email", () => {
+        const emailOrder: NotificationOrderResponse = {
+            ...baseOrder,
+            notifications: [
+                {
+                    id: "notif-1",
+                    succeeded: true,
+                    recipient: { emailAddress: "test@test.no"},
+                    sendStatus: { status: "SENT", description: "Sendt", lastUpdate: "2026-01-01T00:00:00Z" },
+                },
+            ],
+        };
+
+        render(<NotificationOrderSummary order={emailOrder} />);
+
+        expect(screen.getByText("E-post")).toBeInTheDocument();
+    });
+
+    it("should show 'SMS' when the first notification is an SMS", () => {
+        const smsOrder: NotificationOrderResponse = {
+            ...baseOrder,
+            notifications: [
+                {
+                    id: "notif-2",
+                    succeeded: true,
+                    recipient: { mobileNumber: "12345678"},
+                    sendStatus: { status: "SENT", description: "Sendt", lastUpdate: "2026-01-01T00:00:00Z" },
+                },
+            ],
+        };
+
+        render(<NotificationOrderSummary order={smsOrder} />);
+
+        expect(screen.getByText("SMS")).toBeInTheDocument();
+    });
+})

--- a/frontend/altinn-support-dashboard.client/test/Notifications/NotificationSearchBar.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Notifications/NotificationSearchBar.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
+import NotificationSearchBar from "../../src/components/Notification/NotificationSearchBar";
+
+describe("NotificationSearchBar", () => {
+    it("should render input and buttons", () => {
+        render(<NotificationSearchBar orderId="" setOrderId={vi.fn()} />);
+
+        expect(screen.getByPlaceholderText("Skriv inn ordre-id")).toBeInTheDocument();
+        expect(screen.getByText("x")).toBeInTheDocument();
+    });
+
+    it("should update input value on typing", async () => {
+        render(<NotificationSearchBar orderId="" setOrderId={vi.fn()} />);
+        const user = userEvent.setup();
+
+        const input = screen.getByPlaceholderText("Skriv inn ordre-id");
+        await user.type(input, "abc-123");
+
+        expect(input).toHaveValue("abc-123");
+    });
+
+    it("should call setOrderId on search button click", async () => {
+        const setOrderId = vi.fn();
+        render(<NotificationSearchBar orderId="" setOrderId={setOrderId} />);
+        const user = userEvent.setup();
+
+        const input = screen.getByPlaceholderText("Skriv inn ordre-id");
+        await user.type(input, "order-42");
+        const buttons = screen.getAllByRole("button");
+        await user.click(buttons[0]);
+
+        expect(setOrderId).toHaveBeenCalledWith("order-42");
+    });
+
+    it("should call setOrderId on Enter key", async () => {
+        const setOrderId = vi.fn();
+        render(<NotificationSearchBar orderId="" setOrderId={setOrderId} />);
+        const user = userEvent.setup();
+
+        const input = screen.getByPlaceholderText("Skriv inn ordre-id");
+        await user.type(input, "order-99{Enter}");
+
+        expect(setOrderId).toHaveBeenCalledWith("order-99");
+    });
+
+    it("should clear input and call setOrderId with empty string on clear button click", async () => {
+        const setOrderId = vi.fn();
+        render(<NotificationSearchBar orderId="" setOrderId={setOrderId} />);
+        const user = userEvent.setup();
+
+        const input = screen.getByPlaceholderText("Skriv inn ordre-id");
+        await user.type(input, "some-value");
+        await user.click(screen.getByText("x"));
+
+        expect(input).toHaveValue("");
+        expect(setOrderId).toHaveBeenCalledWith("");
+    });
+
+    it("should initialize input with provided orderId", () => {
+        render(<NotificationSearchBar orderId="existing-id" setOrderId={vi.fn()} />);
+
+        expect(screen.getByPlaceholderText("Skriv inn ordre-id")).toHaveValue("existing-id");
+    });
+});

--- a/frontend/altinn-support-dashboard.client/test/Notifications/NotificationStatusCode.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Notifications/NotificationStatusCode.test.tsx
@@ -24,7 +24,7 @@ describe("NotificationStatusCode", () => {
         expect(screen.getByText("Delivered - Delivered successfully")).toBeInTheDocument();
     });
 
-    it("should use success color for delievred status", () => {
+    it("should use success color for delivered status", () => {
         const notification = makeNotifications("Delivered", "Delivered successfully", true);
         render(<NotificationStatusCode notification={notification} />);
 
@@ -38,18 +38,18 @@ describe("NotificationStatusCode", () => {
         expect(screen.getByText("Failed - Failed to deliver")).toHaveAttribute("data-color", "danger");
     });
 
-    it("should use warning color for new status", () => {
+    it("should use info color for new status", () => {
         const notification = makeNotifications("New", "Pending", false);
         render(<NotificationStatusCode notification={notification} />);
 
-        expect(screen.getByText("New - Pending")).toHaveAttribute("data-color", "warning");
+        expect(screen.getByText("New - Pending")).toHaveAttribute("data-color", "info");
     });
 
-    it("should use ifo color for unknown status", () => {
+    it("should use danger color for unknown status", () => {
         const notification = makeNotifications("Unknown", "Unknown status", false);
         render(<NotificationStatusCode notification={notification} />);
 
-        expect(screen.getByText("Unknown - Unknown status")).toHaveAttribute("data-color", "info");
+        expect(screen.getByText("Unknown - Unknown status")).toHaveAttribute("data-color", "danger");
     });
 
     it("should be case insensitive for status matching", () => {

--- a/frontend/altinn-support-dashboard.client/test/Notifications/NotificationStatusCode.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Notifications/NotificationStatusCode.test.tsx
@@ -1,0 +1,61 @@
+import { NotificationItem } from "../../src/models/notificationModels";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import NotificationStatusCode from "../../src/components/Notification/NotificationStatusCode";
+
+
+
+
+
+
+const makeNotifications = (status: string, description: string, succeeded: boolean): NotificationItem => ({
+    id: "notif-1",
+    succeeded,
+    recipient: { emailAddress: "test@test.no"},
+    sendStatus: { status, description, lastUpdate: "2026-01-01T00:00:00Z" },
+});
+
+describe("NotificationStatusCode", () => {
+    it("should render status and description", () => {
+        const notification = makeNotifications("Delivered", "Delivered successfully", true);
+        render(<NotificationStatusCode notification={notification} />);
+
+        expect(screen.getByText("Delivered - Delivered successfully")).toBeInTheDocument();
+    });
+
+    it("should use success color for delievred status", () => {
+        const notification = makeNotifications("Delivered", "Delivered successfully", true);
+        render(<NotificationStatusCode notification={notification} />);
+
+        expect(screen.getByText("Delivered - Delivered successfully")).toHaveAttribute("data-color", "success");
+    })
+
+    it("should use danger color for failed status", () => {
+        const notification = makeNotifications("Failed", "Failed to deliver", false);
+        render(<NotificationStatusCode notification={notification} />);
+
+        expect(screen.getByText("Failed - Failed to deliver")).toHaveAttribute("data-color", "danger");
+    });
+
+    it("should use warning color for new status", () => {
+        const notification = makeNotifications("New", "Pending", false);
+        render(<NotificationStatusCode notification={notification} />);
+
+        expect(screen.getByText("New - Pending")).toHaveAttribute("data-color", "warning");
+    });
+
+    it("should use ifo color for unknown status", () => {
+        const notification = makeNotifications("Unknown", "Unknown status", false);
+        render(<NotificationStatusCode notification={notification} />);
+
+        expect(screen.getByText("Unknown - Unknown status")).toHaveAttribute("data-color", "info");
+    });
+
+    it("should be case insensitive for status matching", () => {
+        const notification = makeNotifications("deLIVereD", "Delivered successfully", true);
+        render(<NotificationStatusCode notification={notification} />);
+
+        expect(screen.getByText("deLIVereD - Delivered successfully")).toHaveAttribute("data-color", "success");
+    });
+})


### PR DESCRIPTION
Made a new page for Notification, and also added a sidebar tab for it.

- Made a search bar that searches using the order-id, for notifications for sms and email.
- Made it so that the results get grouped together based on wether or not they are sms or email notifications. If one of them is empty, only the one with values get shown.
- Added the ability to filter for spesific notifications based on notification ID
- Made new models for the frontend, based on the backend models.
- Added some styling with modules
- Added tests for the new components


