### PR TITLE
Remove hard filter and change search in resource search

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Services/ResourceRegistryService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/ResourceRegistryService.cs
@@ -38,8 +38,8 @@ public class ResourceRegistryService : IResourceRegistryService
         var response = await GetCachedResourceList(environmentName);
 
         return response.Where(r =>
-            r.ResourceType == "AltinnApp" &&
-            r.Title?.Values.Any(v => v.Contains(query, StringComparison.OrdinalIgnoreCase)) == true
+            r.Title?.Values.Any(v => v.Contains(query, StringComparison.OrdinalIgnoreCase)) == true ||
+            r.Identifier?.Contains(query, StringComparison.OrdinalIgnoreCase) == true
         ).ToList();   
     }
 

--- a/frontend/altinn-support-dashboard.client/src/components/ResourceSearch/ResourceSearchList.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/ResourceSearch/ResourceSearchList.tsx
@@ -15,6 +15,7 @@ interface ResourceSearchListProps {
     query: string;
     onlyDelegable: boolean;
     onlyVisible: boolean;
+    onlyAltinnApp: boolean;
 }
 
 export const ResourceSearchList: React.FC<ResourceSearchListProps> = ({
@@ -22,12 +23,15 @@ export const ResourceSearchList: React.FC<ResourceSearchListProps> = ({
     setSelectedResource,
     query,
     onlyDelegable,
-    onlyVisible
+    onlyVisible,
+    onlyAltinnApp
 }) => {
     const environment = useAppStore((state) => state.environment);
     const { resourceQuery } = useResourceSearch(environment, query);
     const resources = (resourceQuery.data ?? []).filter(
-        (r) => (!onlyDelegable || r.delegable === true) && (!onlyVisible || r.visible === true)
+        (r) => (!onlyDelegable || r.delegable === true) && 
+        (!onlyVisible || r.visible === true) &&
+        (!onlyAltinnApp || r.resourceType === "AltinnApp")
     );
 
     useEffect(() => {

--- a/frontend/altinn-support-dashboard.client/src/components/ResourceSearch/ResourceSearchSearchBar.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/ResourceSearch/ResourceSearchSearchBar.tsx
@@ -11,6 +11,8 @@ type ResourceSearchSearchBarProps = {
   setOnlyDelegable: (value: boolean) => void;
   onlyVisible: boolean;
   setOnlyVisible: (value: boolean) => void;
+  onlyAltinnApp: boolean;
+  setOnlyAltinnApp: (value: boolean) => void;
 };
 
 export const ResourceSearchSearchBar: React.FC<ResourceSearchSearchBarProps> = ({
@@ -20,7 +22,9 @@ export const ResourceSearchSearchBar: React.FC<ResourceSearchSearchBarProps> = (
   onlyDelegable,
   setOnlyDelegable,
   onlyVisible,
-  setOnlyVisible
+  setOnlyVisible,
+  onlyAltinnApp,
+  setOnlyAltinnApp
 }) => {
   const [textFieldValue, setTextFieldValue] = useState(query)
 
@@ -73,6 +77,13 @@ export const ResourceSearchSearchBar: React.FC<ResourceSearchSearchBarProps> = (
           checked={onlyVisible}
           onChange={(e) => setOnlyVisible(e.target.checked)}
         />
+        <Checkbox
+          label="Kun AltinnApp"
+          value="altinnApp"
+          checked={onlyAltinnApp}
+          onChange={(e) => setOnlyAltinnApp(e.target.checked)}
+        />
+
       </div>
     </div>
   );

--- a/frontend/altinn-support-dashboard.client/src/pages/ResourceSearchPage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/ResourceSearchPage.tsx
@@ -14,6 +14,7 @@ export const ResourceSearchPage = () => {
   
   const [onlyDelegable, setOnlyDelegable] = useState(false);
   const [onlyVisible, setOnlyVisible] = useState(false);
+  const [onlyAltinnApp, setOnlyAltinnApp] = useState(true);
 
   return (
     <div className={styles.pageContainer}>
@@ -28,6 +29,8 @@ export const ResourceSearchPage = () => {
         setOnlyDelegable={setOnlyDelegable}
         onlyVisible={onlyVisible}
         setOnlyVisible={setOnlyVisible}
+        onlyAltinnApp={onlyAltinnApp}
+        setOnlyAltinnApp={setOnlyAltinnApp}
       />
       <div className={styles.mainContainer}>
         <div className={styles.listContainer}>
@@ -37,6 +40,7 @@ export const ResourceSearchPage = () => {
             setSelectedResource={setSelectedResource}
             onlyDelegable={onlyDelegable}
             onlyVisible={onlyVisible}
+            onlyAltinnApp={onlyAltinnApp}
           />
         </div>
         <div className={styles.detailedContainer}>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the hardcoded ResourceType == "AltinnApp" filter from the backend search, replacing it with an optional frontend checkbox (defaults to checked, preserving existing behavior)
Extends the backend search to also match on resource identifier, so users can search by resource ID in addition to title

## Related Issue(s)
- #751 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
