### PR TITLE
748 velge sikkerhetsnivå på melding

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
@@ -48,7 +48,7 @@ public class CorrespondenceClient : ICorrespondenceClient
                 form.Add(new StringContent(resourceTypes.SelfIdentifiedResourceId.ToString()), "correspondence.resourceid");
                 break;
             case "securitylvl4":
-                form.Add(new StringContent(resourceTypes.SecurityLvl4ResourceId), "correspondence.resourceId");
+                form.Add(new StringContent(resourceTypes.SecurityLvl4ResourceId.ToString()), "correspondence.resourceid");
                 break;
             default:
                 throw new BadRequestException($"ResourceType {correspondenceData.Correspondence.ResourceType} not valid");

--- a/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
@@ -47,6 +47,9 @@ public class CorrespondenceClient : ICorrespondenceClient
             case "selfIdentified":
                 form.Add(new StringContent(resourceTypes.SelfIdentifiedResourceId.ToString()), "correspondence.resourceid");
                 break;
+            case "securitylvl4":
+                form.Add(new StringContent(resourceTypes.SecurityLvl4ResourceId), "correspondence.resourceId");
+                break;
             default:
                 throw new BadRequestException($"ResourceType {correspondenceData.Correspondence.ResourceType} not valid");
         }

--- a/backend/src/altinn-support-dashboard.backend/Models/correspondence/CorrespondenceResourceType.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/correspondence/CorrespondenceResourceType.cs
@@ -5,4 +5,5 @@ public class CorrespondenceResourceType
     public required string DefaultResourceId { get; set; }
     public required string ConfidentialityResourceId { get; set; }
     public required string SelfIdentifiedResourceId { get; set; }
+    public required string SecurityLvl4ResourceId { get; set; }
 }

--- a/backend/src/altinn-support-dashboard.backend/appsettings.json
+++ b/backend/src/altinn-support-dashboard.backend/appsettings.json
@@ -40,7 +40,8 @@
     "Correspondence": {
       "defaultResourceid": "ttd-asd-correspondence",
       "confidentialityResourceId": "ttd-asd-correspondence-confidentiality",
-      "selfIdentifiedResourceId": "ttd-asd-correspondence-selfidentified"
+      "selfIdentifiedResourceId": "ttd-asd-correspondence-selfidentified",
+      "SecurityLvl4":"ttd-asd-correspondence-lvl4"
     }
   },
   "AnsattportenLoginSettings": {

--- a/backend/src/altinn-support-dashboard.backend/appsettings.json
+++ b/backend/src/altinn-support-dashboard.backend/appsettings.json
@@ -41,7 +41,7 @@
       "defaultResourceid": "ttd-asd-correspondence",
       "confidentialityResourceId": "ttd-asd-correspondence-confidentiality",
       "selfIdentifiedResourceId": "ttd-asd-correspondence-selfidentified",
-      "SecurityLvl4":"ttd-asd-correspondence-lvl4"
+      "SecurityLvl4ResourceId":"ttd-asd-correspondence-lvl4"
     }
   },
   "AnsattportenLoginSettings": {

--- a/backend/test/altinn-support-dashboard.backend.Tests/Services/Altinn3ServiceTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Services/Altinn3ServiceTests.cs
@@ -54,7 +54,7 @@ public class Altinn3ServiceTests
                 MaskinportenSettings = new MaskinportenSettings
                 { }
             },
-            Correspondence = new CorrespondenceResourceType { DefaultResourceId = "default", ConfidentialityResourceId = "confident", SelfIdentifiedResourceId = "self" }
+            Correspondence = new CorrespondenceResourceType { DefaultResourceId = "default", ConfidentialityResourceId = "confident", SelfIdentifiedResourceId = "self", SecurityLvl4ResourceId = "lvl4" }
         });
         mockHttpClient.Setup(x => x.CreateClient(It.IsAny<string>()))
             .Returns(new HttpClient());

--- a/frontend/altinn-support-dashboard.client/src/components/Correspondence/CorrespondenceResourceType.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Correspondence/CorrespondenceResourceType.tsx
@@ -26,6 +26,7 @@ const CorrespondenceResourceType: React.FC<CorrespondenceResourceTypeProps> = ({
           Taushetsbelagt post
         </Select.Option>
         <Select.Option value="default">Ordinær post</Select.Option>
+        <Select.Option value="securitylvl4">Sikkerhetsnivå 4</Select.Option>
       </Select>
     </div>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for security level 4 ("Sikkerhetsnivå 4") as a selectable resource type when sending correspondence.

- Frontend: Added a new Select.Option with value securitylvl4 and label "Sikkerhetsnivå 4" to the CorrespondenceResourceType component.
- Backend model: Added SecurityLvl4ResourceId property to CorrespondenceResourceType.
- Backend logic: Added a securitylvl4 case in CorrespondenceClient that maps to the new resource ID.
- Configuration: Added SecurityLvl4ResourceId (ttd-asd-correspondence-lvl4) to appsettings.json.

## Related Issue(s)
- #748 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
