### PR TITLE
732 add getnotificationsbynin endpoint to backend

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Clients/Interfaces/INotificationsClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Interfaces/INotificationsClient.cs
@@ -2,4 +2,5 @@ public interface INotificationsClient
 {
     Task<string> GetEmailNotificationsByOrderId(string orderId);
     Task<string> GetSmsNotificationsByOrderId(string orderId);
+    Task<string> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to);
 }

--- a/backend/src/altinn-support-dashboard.backend/Clients/Interfaces/INotificationsClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Interfaces/INotificationsClient.cs
@@ -1,6 +1,6 @@
 public interface INotificationsClient
 {
-    Task<string> GetEmailNotificationsByOrderId(string orderId);
-    Task<string> GetSmsNotificationsByOrderId(string orderId);
-    Task<string> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to);
+    Task<string> GetEmailNotificationsByOrderId(string orderId, string environmentName);
+    Task<string> GetSmsNotificationsByOrderId(string orderId, string environmentName);
+    Task<string> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to, string environmentName);
 }

--- a/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
@@ -49,4 +49,37 @@ public class NotificationsClient : INotificationsClient
 
         return responseBody;
     }
+
+    public async Task<string> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to)
+    {
+        var query = new List<string>();
+
+        if (from.HasValue)
+        {
+            query.Add($"from={Uri.EscapeDataString(from.Value.ToString("O"))}");
+        }
+        if (to.HasValue)
+        {
+            query.Add($"to={Uri.EscapeDataString(to.Value.ToString("O"))}");
+        }
+        var url = "notifications/api/v1/future/dashboard/recipients/notifications/nin";
+        if (query.Count > 0) url += "?" + string.Join("&", query);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        //nin is set in header
+        request.Headers.Add("NationalIdentityNumber", nin);
+        var response = await _client.SendAsync(request);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException(
+                $"Api request failed with status code {response.StatusCode}: {responseBody}",
+                inner: null,
+                statusCode: response.StatusCode);
+        }
+
+        return responseBody;
+    }
 }

--- a/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
@@ -3,24 +3,30 @@ using Microsoft.Extensions.Options;
 
 public class NotificationsClient : INotificationsClient
 {
-    private readonly HttpClient _client;
+    private readonly Dictionary<string, HttpClient> _clients = new();
     private readonly ILogger<INotificationsClient> _logger;
 
     public NotificationsClient(IOptions<Configuration> configuration, IHttpClientFactory clientFactory, ILogger<INotificationsClient> logger)
     {
         _logger = logger;
-
-        var tt02 = configuration.Value.TT02;
-        _client = clientFactory.CreateClient(nameof(configuration.Value.TT02));
-        _client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", tt02.Ocp_Apim_Subscription_Key);
-        _client.BaseAddress = new Uri(tt02.BaseAddressAltinn3);
-        _client.Timeout = TimeSpan.FromSeconds(tt02.Timeout);
-        _client.DefaultRequestHeaders.Add("ApiKey", tt02.ApiKey);
+        InitClient(nameof(configuration.Value.TT02), configuration.Value.TT02, clientFactory);
+        InitClient(nameof(configuration.Value.Production), configuration.Value.Production, clientFactory);
     }
 
-    public async Task<string> GetEmailNotificationsByOrderId(string orderId)
+    private void InitClient(string environmentName, EnvironmentConfiguration config, IHttpClientFactory clientFactory)
     {
-        var response = await _client.GetAsync($"notifications/api/v1/orders/{orderId}/notifications/email");
+        var client = clientFactory.CreateClient(environmentName);
+        client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", config.Ocp_Apim_Subscription_Key);
+        client.BaseAddress = new Uri(config.BaseAddressAltinn3);
+        client.Timeout = TimeSpan.FromSeconds(config.Timeout);
+        client.DefaultRequestHeaders.Add("ApiKey", config.ApiKey);
+        _clients.Add(environmentName, client);
+    }
+
+    public async Task<string> GetEmailNotificationsByOrderId(string orderId, string environmentName)
+    {
+        var client = _clients[environmentName];
+        var response = await client.GetAsync($"notifications/api/v1/orders/{orderId}/notifications/email");
         var responseBody = await response.Content.ReadAsStringAsync();
 
         if (!response.IsSuccessStatusCode)
@@ -34,9 +40,10 @@ public class NotificationsClient : INotificationsClient
         return responseBody;
     }
 
-    public async Task<string> GetSmsNotificationsByOrderId(string orderId)
+    public async Task<string> GetSmsNotificationsByOrderId(string orderId, string environmentName)
     {
-        var response = await _client.GetAsync($"notifications/api/v1/orders/{orderId}/notifications/sms");
+        var client = _clients[environmentName];
+        var response = await client.GetAsync($"notifications/api/v1/orders/{orderId}/notifications/sms");
         var responseBody = await response.Content.ReadAsStringAsync();
 
         if (!response.IsSuccessStatusCode)
@@ -50,8 +57,9 @@ public class NotificationsClient : INotificationsClient
         return responseBody;
     }
 
-    public async Task<string> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to)
+    public async Task<string> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to, string environmentName)
     {
+        var client = _clients[environmentName];
         var query = new List<string>();
 
         if (from.HasValue)
@@ -69,7 +77,7 @@ public class NotificationsClient : INotificationsClient
 
         //nin is set in header
         request.Headers.Add("NationalIdentityNumber", nin);
-        var response = await _client.SendAsync(request);
+        var response = await client.SendAsync(request);
         var responseBody = await response.Content.ReadAsStringAsync();
 
         if (!response.IsSuccessStatusCode)

--- a/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/NotificationsClient.cs
@@ -71,7 +71,10 @@ public class NotificationsClient : INotificationsClient
             query.Add($"to={Uri.EscapeDataString(to.Value.ToString("O"))}");
         }
         var url = "notifications/api/v1/future/dashboard/recipients/notifications/nin";
-        if (query.Count > 0) url += "?" + string.Join("&", query);
+        if (query.Count > 0)
+        {
+            url += "?" + string.Join("&", query);
+        }
 
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
 

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -7,8 +7,7 @@ using Security;
 namespace AltinnSupportDashboard.Controllers;
 
 [ApiController]
-[Route("api/notifications")]
-//added authorization temporary
+[Route("api/{environmentName}/notifications")]
 [Authorize(AzureRoles.Authenticated)]
 [Authorize(AzureRoles.CoreInternal)]
 public class NotificationsController : ControllerBase
@@ -23,48 +22,43 @@ public class NotificationsController : ControllerBase
     }
 
     [HttpGet("orderid/email/{orderId}")]
-    public async Task<IActionResult> GetEmailNotificationsByOrderId(string orderId)
+    public async Task<IActionResult> GetEmailNotificationsByOrderId([FromRoute] string environmentName, string orderId)
     {
         if (!ValidationService.IsValidNotificationOrderId(orderId))
-        {
             return BadRequest(InvalidOrderIdMessage);
-        }
 
-        var response = await _service.GetEmailNotificationsByOrderId(orderId);
+        var response = await _service.GetEmailNotificationsByOrderId(orderId, environmentName);
         return Ok(response);
     }
 
     [HttpGet("orderid/sms/{orderId}")]
-    public async Task<IActionResult> GetSmsNotificationsByOrderId(string orderId)
+    public async Task<IActionResult> GetSmsNotificationsByOrderId([FromRoute] string environmentName, string orderId)
     {
         if (!ValidationService.IsValidNotificationOrderId(orderId))
-        {
             return BadRequest(InvalidOrderIdMessage);
-        }
 
-        var response = await _service.GetSmsNotificationsByOrderId(orderId);
+        var response = await _service.GetSmsNotificationsByOrderId(orderId, environmentName);
         return Ok(response);
     }
 
     [HttpGet("orderid/{orderId}")]
-    public async Task<IActionResult> GetAllNotificationsByOrderId(string orderId)
+    public async Task<IActionResult> GetAllNotificationsByOrderId([FromRoute] string environmentName, string orderId)
     {
         if (!ValidationService.IsValidNotificationOrderId(orderId))
-        {
             return BadRequest(InvalidOrderIdMessage);
-        }
 
-        var response = await _service.GetAllNotificationsByOrderId(orderId);
+        var response = await _service.GetAllNotificationsByOrderId(orderId, environmentName);
         return Ok(response);
     }
 
     [HttpGet("future/nin")]
     public async Task<IActionResult> GetFutureNotificationsByNin(
+        [FromRoute] string environmentName,
         [FromHeader(Name = "NationalIdentityNumber")] string nationalIdentityNumber,
         [FromQuery] DateTime? from,
         [FromQuery] DateTime? to)
     {
-        var response = await _service.GetFutureNotificationsByNin(nationalIdentityNumber, from, to);
+        var response = await _service.GetFutureNotificationsByNin(nationalIdentityNumber, from, to, environmentName);
         return Ok(response);
     }
 }

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -51,14 +51,14 @@ public class NotificationsController : ControllerBase
         return Ok(response);
     }
 
-    [HttpGet("future/nin")]
+    [HttpGet("future/nin/{nin}")]
     public async Task<IActionResult> GetFutureNotificationsByNin(
         [FromRoute] string environmentName,
-        [FromHeader(Name = "NationalIdentityNumber")] string nationalIdentityNumber,
+        [FromRoute] string nin,
         [FromQuery] DateTime? from,
         [FromQuery] DateTime? to)
     {
-        var response = await _service.GetFutureNotificationsByNin(nationalIdentityNumber, from, to, environmentName);
+        var response = await _service.GetFutureNotificationsByNin(nin, from, to, environmentName);
         return Ok(response);
     }
 }

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -57,4 +57,14 @@ public class NotificationsController : ControllerBase
         var response = await _service.GetAllNotificationsByOrderId(orderId);
         return Ok(response);
     }
+
+    [HttpGet("future/nin")]
+    public async Task<IActionResult> GetFutureNotificationsByNin(
+        [FromHeader(Name = "NationalIdentityNumber")] string nationalIdentityNumber,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to)
+    {
+        var response = await _service.GetFutureNotificationsByNin(nationalIdentityNumber, from, to);
+        return Ok(response);
+    }
 }

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -12,7 +12,7 @@ namespace AltinnSupportDashboard.Controllers;
 [Authorize(AzureRoles.CoreInternal)]
 public class NotificationsController : ControllerBase
 {
-    private const string InvalidOrderIdMessage = "Ordre-ID is invalid. It should be in GUID format";
+    private const string InvalidOrderIdMessage = "Order-ID is invalid. It should be in GUID format";
 
     private readonly INotificationsService _service;
 

--- a/backend/src/altinn-support-dashboard.backend/Models/notifications/FutureNotificationDeliveryAttemptDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/notifications/FutureNotificationDeliveryAttemptDto.cs
@@ -1,0 +1,19 @@
+namespace Models.notifications;
+
+
+
+public class FutureNotificationDeliveryAttemptDto
+{
+
+	public string? NationalIdentityNumber { get; set; }
+
+	public string? Channel { get; set; }
+
+	public string? EmailAddress { get; set; }
+
+	public string? MobileNumber { get; set; }
+
+	public string? Result { get; set; }
+
+	public DateTime? ResultTime { get; set; }
+}

--- a/backend/src/altinn-support-dashboard.backend/Models/notifications/FutureNotificationDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/notifications/FutureNotificationDto.cs
@@ -14,6 +14,8 @@ public class FutureNotificationDto
 
 	public string? NotificationChannel { get; set; }
 
+	public string? NotificationType { get; set; }
+
 	public List<FutureNotificationDeliveryAttemptDto?> DeliveryAttempts { get; set; } = [];
 
 }

--- a/backend/src/altinn-support-dashboard.backend/Models/notifications/FutureNotificationDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/notifications/FutureNotificationDto.cs
@@ -1,0 +1,20 @@
+namespace Models.notifications;
+
+public class FutureNotificationDto
+{
+	public Guid ShipmentId { get; set; }
+
+	public required string CreatorName { get; set; }
+
+	public string? ResourceId { get; set; }
+
+	public string? SendersReference { get; set; }
+
+	public DateTime RequestedSendTime { get; set; }
+
+	public string? NotificationChannel { get; set; }
+
+	public List<FutureNotificationDeliveryAttemptDto?> DeliveryAttempts { get; set; } = [];
+
+}
+

--- a/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
@@ -7,4 +7,5 @@ public interface INotificationsService
     Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId);
     Task<NotificationOrderResponseDto> GetSmsNotificationsByOrderId(string orderId);
     Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId);
+    Task<List<FutureNotificationDto>> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to);
 }

--- a/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/Interfaces/INotificationsService.cs
@@ -4,8 +4,8 @@ namespace altinn_support_dashboard.Server.Services.Interfaces;
 
 public interface INotificationsService
 {
-    Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId);
-    Task<NotificationOrderResponseDto> GetSmsNotificationsByOrderId(string orderId);
-    Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId);
-    Task<List<FutureNotificationDto>> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to);
+    Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId, string environmentName);
+    Task<NotificationOrderResponseDto> GetSmsNotificationsByOrderId(string orderId, string environmentName);
+    Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId, string environmentName);
+    Task<List<FutureNotificationDto>> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to, string environmentName);
 }

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
@@ -22,6 +22,12 @@ public class NotificationsService : INotificationsService
         _logger = logger;
     }
 
+    public async Task<List<FutureNotificationDto>> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to, string environmentName)
+    {
+        var result = await _client.GetFutureNotificationsByNin(nin, from, to, environmentName);
+        return JsonSerializer.Deserialize<List<FutureNotificationDto>>(result, _jsonOptions) ?? throw new Exception("Error deserializing future notifications response");
+    }
+
     public async Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId, string environmentName)
     {
         var result = await _client.GetEmailNotificationsByOrderId(orderId, environmentName);
@@ -34,11 +40,6 @@ public class NotificationsService : INotificationsService
         return JsonSerializer.Deserialize<NotificationOrderResponseDto>(result, _jsonOptions) ?? throw new Exception("Error deserializing SMS notifications response");
     }
 
-    public async Task<List<FutureNotificationDto>> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to, string environmentName)
-    {
-        var result = await _client.GetFutureNotificationsByNin(nin, from, to, environmentName);
-        return JsonSerializer.Deserialize<List<FutureNotificationDto>>(result, _jsonOptions) ?? throw new Exception("Error deserializing future notifications response");
-    }
 
     public async Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId, string environmentName)
     {

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
@@ -22,28 +22,28 @@ public class NotificationsService : INotificationsService
         _logger = logger;
     }
 
-    public async Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId)
+    public async Task<NotificationOrderResponseDto> GetEmailNotificationsByOrderId(string orderId, string environmentName)
     {
-        var result = await _client.GetEmailNotificationsByOrderId(orderId);
+        var result = await _client.GetEmailNotificationsByOrderId(orderId, environmentName);
         return JsonSerializer.Deserialize<NotificationOrderResponseDto>(result, _jsonOptions) ?? throw new Exception("Error deserializing email notifications response");
     }
 
-    public async Task<NotificationOrderResponseDto> GetSmsNotificationsByOrderId(string orderId)
+    public async Task<NotificationOrderResponseDto> GetSmsNotificationsByOrderId(string orderId, string environmentName)
     {
-        var result = await _client.GetSmsNotificationsByOrderId(orderId);
+        var result = await _client.GetSmsNotificationsByOrderId(orderId, environmentName);
         return JsonSerializer.Deserialize<NotificationOrderResponseDto>(result, _jsonOptions) ?? throw new Exception("Error deserializing SMS notifications response");
     }
 
-    public async Task<List<FutureNotificationDto>> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to)
+    public async Task<List<FutureNotificationDto>> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to, string environmentName)
     {
-        var result = await _client.GetFutureNotificationsByNin(nin, from, to);
+        var result = await _client.GetFutureNotificationsByNin(nin, from, to, environmentName);
         return JsonSerializer.Deserialize<List<FutureNotificationDto>>(result, _jsonOptions) ?? throw new Exception("Error deserializing future notifications response");
     }
 
-    public async Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId)
+    public async Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId, string environmentName)
     {
-        var smsTask = GetSmsNotificationsByOrderId(orderId);
-        var emailTask = GetEmailNotificationsByOrderId(orderId);
+        var smsTask = GetSmsNotificationsByOrderId(orderId, environmentName);
+        var emailTask = GetEmailNotificationsByOrderId(orderId, environmentName);
 
         // runs the tasks in parrallel
         await Task.WhenAll(

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationsService.cs
@@ -34,6 +34,12 @@ public class NotificationsService : INotificationsService
         return JsonSerializer.Deserialize<NotificationOrderResponseDto>(result, _jsonOptions) ?? throw new Exception("Error deserializing SMS notifications response");
     }
 
+    public async Task<List<FutureNotificationDto>> GetFutureNotificationsByNin(string nin, DateTime? from, DateTime? to)
+    {
+        var result = await _client.GetFutureNotificationsByNin(nin, from, to);
+        return JsonSerializer.Deserialize<List<FutureNotificationDto>>(result, _jsonOptions) ?? throw new Exception("Error deserializing future notifications response");
+    }
+
     public async Task<List<NotificationOrderResponseDto>> GetAllNotificationsByOrderId(string orderId)
     {
         var smsTask = GetSmsNotificationsByOrderId(orderId);

--- a/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
@@ -11,6 +11,7 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
     {
         private const string ValidOrderId = "dec90ca7-4f8d-410f-96ed-666fe019c946";
         private const string OtherValidOrderId = "11111111-2222-3333-4444-555555555555";
+        private const string EnvironmentName = "TT02";
 
         private readonly NotificationsController _controller;
         private readonly Mock<INotificationsService> _serviceMock;
@@ -28,9 +29,9 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
             {
                 OrderId = ValidOrderId, SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = []
             };
-            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(ValidOrderId)).ReturnsAsync(response);
+            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(ValidOrderId, EnvironmentName)).ReturnsAsync(response);
 
-            var result = await _controller.GetEmailNotificationsByOrderId(ValidOrderId);
+            var result = await _controller.GetEmailNotificationsByOrderId(EnvironmentName, ValidOrderId);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
             Assert.Equal(response, okResult.Value);
@@ -39,24 +40,24 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
         [Fact]
         public async Task GetEmailNotificationsByOrderId_CallsService_WithCorrectOrderId()
         {
-            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(ValidOrderId))
+            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(ValidOrderId, EnvironmentName))
                 .ReturnsAsync(new NotificationOrderResponseDto
                 {
                     OrderId = ValidOrderId, SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = []
                 });
 
-            await _controller.GetEmailNotificationsByOrderId(ValidOrderId);
+            await _controller.GetEmailNotificationsByOrderId(EnvironmentName, ValidOrderId);
 
-            _serviceMock.Verify(s => s.GetEmailNotificationsByOrderId(ValidOrderId), Times.Once);
+            _serviceMock.Verify(s => s.GetEmailNotificationsByOrderId(ValidOrderId, EnvironmentName), Times.Once);
         }
 
         [Fact]
         public async Task GetEmailNotificationsByOrderId_PropagatesException_WhenServiceThrows()
         {
-            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(It.IsAny<string>()))
+            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Service failure"));
 
-            await Assert.ThrowsAsync<Exception>(() => _controller.GetEmailNotificationsByOrderId(ValidOrderId));
+            await Assert.ThrowsAsync<Exception>(() => _controller.GetEmailNotificationsByOrderId(EnvironmentName, ValidOrderId));
         }
 
         [Fact]
@@ -66,9 +67,9 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
             {
                 OrderId = OtherValidOrderId, SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = []
             };
-            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId(OtherValidOrderId)).ReturnsAsync(response);
+            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId(OtherValidOrderId, EnvironmentName)).ReturnsAsync(response);
 
-            var result = await _controller.GetSmsNotificationsByOrderId(OtherValidOrderId);
+            var result = await _controller.GetSmsNotificationsByOrderId(EnvironmentName, OtherValidOrderId);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
             Assert.Equal(response, okResult.Value);
@@ -77,24 +78,24 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
         [Fact]
         public async Task GetSmsNotificationsByOrderId_CallsService_WithCorrectOrderId()
         {
-            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId(OtherValidOrderId))
+            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId(OtherValidOrderId, EnvironmentName))
                 .ReturnsAsync(new NotificationOrderResponseDto
                 {
                     OrderId = OtherValidOrderId, SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = []
                 });
 
-            await _controller.GetSmsNotificationsByOrderId(OtherValidOrderId);
+            await _controller.GetSmsNotificationsByOrderId(EnvironmentName, OtherValidOrderId);
 
-            _serviceMock.Verify(s => s.GetSmsNotificationsByOrderId(OtherValidOrderId), Times.Once);
+            _serviceMock.Verify(s => s.GetSmsNotificationsByOrderId(OtherValidOrderId, EnvironmentName), Times.Once);
         }
 
         [Fact]
         public async Task GetSmsNotificationsByOrderId_PropagatesException_WhenServiceThrows()
         {
-            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId(It.IsAny<string>()))
+            _serviceMock.Setup(s => s.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Service failure"));
 
-            await Assert.ThrowsAsync<Exception>(() => _controller.GetSmsNotificationsByOrderId(OtherValidOrderId));
+            await Assert.ThrowsAsync<Exception>(() => _controller.GetSmsNotificationsByOrderId(EnvironmentName, OtherValidOrderId));
         }
 
         [Theory]
@@ -106,10 +107,10 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
         [InlineData("   ")]
         public async Task GetEmailNotificationsByOrderId_ReturnsBadRequest_WhenOrderIdIsNotGuid(string orderId)
         {
-            var result = await _controller.GetEmailNotificationsByOrderId(orderId);
+            var result = await _controller.GetEmailNotificationsByOrderId(EnvironmentName, orderId);
 
             Assert.IsType<BadRequestObjectResult>(result);
-            _serviceMock.Verify(s => s.GetEmailNotificationsByOrderId(It.IsAny<string>()), Times.Never);
+            _serviceMock.Verify(s => s.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         [Theory]
@@ -118,10 +119,10 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
         [InlineData("")]
         public async Task GetSmsNotificationsByOrderId_ReturnsBadRequest_WhenOrderIdIsNotGuid(string orderId)
         {
-            var result = await _controller.GetSmsNotificationsByOrderId(orderId);
+            var result = await _controller.GetSmsNotificationsByOrderId(EnvironmentName, orderId);
 
             Assert.IsType<BadRequestObjectResult>(result);
-            _serviceMock.Verify(s => s.GetSmsNotificationsByOrderId(It.IsAny<string>()), Times.Never);
+            _serviceMock.Verify(s => s.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         [Theory]
@@ -130,10 +131,10 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
         [InlineData("")]
         public async Task GetAllNotificationsByOrderId_ReturnsBadRequest_WhenOrderIdIsNotGuid(string orderId)
         {
-            var result = await _controller.GetAllNotificationsByOrderId(orderId);
+            var result = await _controller.GetAllNotificationsByOrderId(EnvironmentName, orderId);
 
             Assert.IsType<BadRequestObjectResult>(result);
-            _serviceMock.Verify(s => s.GetAllNotificationsByOrderId(It.IsAny<string>()), Times.Never);
+            _serviceMock.Verify(s => s.GetAllNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         // --- GetFutureNotificationsByNin ---
@@ -145,9 +146,9 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
             {
                 new() { CreatorName = "test-creator", RequestedSendTime = DateTime.UtcNow }
             };
-            _serviceMock.Setup(s => s.GetFutureNotificationsByNin("12345678901", null, null)).ReturnsAsync(response);
+            _serviceMock.Setup(s => s.GetFutureNotificationsByNin("12345678901", null, null, EnvironmentName)).ReturnsAsync(response);
 
-            var result = await _controller.GetFutureNotificationsByNin("12345678901", null, null);
+            var result = await _controller.GetFutureNotificationsByNin(EnvironmentName, "12345678901", null, null);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
             Assert.Equal(response, okResult.Value);
@@ -158,21 +159,21 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
         {
             var from = new DateTime(2024, 1, 1);
             var to = new DateTime(2024, 2, 1);
-            _serviceMock.Setup(s => s.GetFutureNotificationsByNin("12345678901", from, to))
+            _serviceMock.Setup(s => s.GetFutureNotificationsByNin("12345678901", from, to, EnvironmentName))
                 .ReturnsAsync([]);
 
-            await _controller.GetFutureNotificationsByNin("12345678901", from, to);
+            await _controller.GetFutureNotificationsByNin(EnvironmentName, "12345678901", from, to);
 
-            _serviceMock.Verify(s => s.GetFutureNotificationsByNin("12345678901", from, to), Times.Once);
+            _serviceMock.Verify(s => s.GetFutureNotificationsByNin("12345678901", from, to, EnvironmentName), Times.Once);
         }
 
         [Fact]
         public async Task GetFutureNotificationsByNin_PropagatesException_WhenServiceThrows()
         {
-            _serviceMock.Setup(s => s.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+            _serviceMock.Setup(s => s.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Service failure"));
 
-            await Assert.ThrowsAsync<Exception>(() => _controller.GetFutureNotificationsByNin("12345678901", null, null));
+            await Assert.ThrowsAsync<Exception>(() => _controller.GetFutureNotificationsByNin(EnvironmentName, "12345678901", null, null));
         }
     }
 }

--- a/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
@@ -135,5 +135,44 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
             Assert.IsType<BadRequestObjectResult>(result);
             _serviceMock.Verify(s => s.GetAllNotificationsByOrderId(It.IsAny<string>()), Times.Never);
         }
+
+        // --- GetFutureNotificationsByNin ---
+
+        [Fact]
+        public async Task GetFutureNotificationsByNin_ReturnsOk_WithServiceResult()
+        {
+            var response = new List<FutureNotificationDto>
+            {
+                new() { CreatorName = "test-creator", RequestedSendTime = DateTime.UtcNow }
+            };
+            _serviceMock.Setup(s => s.GetFutureNotificationsByNin("12345678901", null, null)).ReturnsAsync(response);
+
+            var result = await _controller.GetFutureNotificationsByNin("12345678901", null, null);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(response, okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetFutureNotificationsByNin_CallsService_WithCorrectParameters()
+        {
+            var from = new DateTime(2024, 1, 1);
+            var to = new DateTime(2024, 2, 1);
+            _serviceMock.Setup(s => s.GetFutureNotificationsByNin("12345678901", from, to))
+                .ReturnsAsync([]);
+
+            await _controller.GetFutureNotificationsByNin("12345678901", from, to);
+
+            _serviceMock.Verify(s => s.GetFutureNotificationsByNin("12345678901", from, to), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetFutureNotificationsByNin_PropagatesException_WhenServiceThrows()
+        {
+            _serviceMock.Setup(s => s.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+                .ThrowsAsync(new Exception("Service failure"));
+
+            await Assert.ThrowsAsync<Exception>(() => _controller.GetFutureNotificationsByNin("12345678901", null, null));
+        }
     }
 }

--- a/backend/test/altinn-support-dashboard.backend.Tests/Services/NotificationsServiceTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Services/NotificationsServiceTests.cs
@@ -160,4 +160,72 @@ public class NotificationsServiceTests
 
         await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetAllNotificationsByOrderId("order-123"));
     }
+
+    // --- GetFutureNotificationsByNin ---
+
+    private const string ValidFutureNotificationsJson = """
+        [
+            {
+                "shipmentId": "dec90ca7-4f8d-410f-96ed-666fe019c946",
+                "creatorName": "test-creator",
+                "resourceId": null,
+                "sendersReference": "ref-1",
+                "requestedSendTime": "2024-01-01T00:00:00",
+                "notificationChannel": "email",
+                "deliveryAttempts": []
+            }
+        ]
+        """;
+
+    [Fact]
+    public async Task GetFutureNotificationsByNin_ReturnsDeserializedResponse_WhenClientSucceeds()
+    {
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+            .ReturnsAsync(ValidFutureNotificationsJson);
+
+        var result = await _service.GetFutureNotificationsByNin("12345678901", null, null);
+
+        Assert.Single(result);
+        Assert.Equal("test-creator", result[0].CreatorName);
+    }
+
+    [Fact]
+    public async Task GetFutureNotificationsByNin_DelegatesToClient_WithCorrectParameters()
+    {
+        var from = new DateTime(2024, 1, 1);
+        var to = new DateTime(2024, 2, 1);
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin("12345678901", from, to))
+            .ReturnsAsync(ValidFutureNotificationsJson);
+
+        await _service.GetFutureNotificationsByNin("12345678901", from, to);
+
+        _clientMock.Verify(c => c.GetFutureNotificationsByNin("12345678901", from, to), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetFutureNotificationsByNin_ThrowsException_WhenClientThrows()
+    {
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+            .ThrowsAsync(new Exception("API request failed"));
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetFutureNotificationsByNin("12345678901", null, null));
+    }
+
+    [Fact]
+    public async Task GetFutureNotificationsByNin_ThrowsJsonException_WhenResponseIsInvalidJson()
+    {
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+            .ReturnsAsync("not-valid-json");
+
+        await Assert.ThrowsAsync<JsonException>(() => _service.GetFutureNotificationsByNin("12345678901", null, null));
+    }
+
+    [Fact]
+    public async Task GetFutureNotificationsByNin_ThrowsException_WhenResponseDeserializesToNull()
+    {
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+            .ReturnsAsync("null");
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetFutureNotificationsByNin("12345678901", null, null));
+    }
 }

--- a/backend/test/altinn-support-dashboard.backend.Tests/Services/NotificationsServiceTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Services/NotificationsServiceTests.cs
@@ -10,6 +10,8 @@ public class NotificationsServiceTests
     private readonly Mock<INotificationsClient> _clientMock;
     private readonly NotificationsService _service;
 
+    private const string EnvironmentName = "TT02";
+
     private const string ValidOrderJson = """
         {
             "orderId": "order-123",
@@ -19,149 +21,6 @@ public class NotificationsServiceTests
             "notifications": []
         }
         """;
-
-    public NotificationsServiceTests()
-    {
-        _clientMock = new Mock<INotificationsClient>();
-        var logger = Mock.Of<ILogger<INotificationsService>>();
-        _service = new NotificationsService(_clientMock.Object, logger);
-    }
-
-    [Fact]
-    public async Task GetEmailNotificationsByOrderId_ReturnsDeserializedResponse_WhenClientSucceeds()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
-
-        var result = await _service.GetEmailNotificationsByOrderId("order-123");
-
-        Assert.Equal("order-123", result.OrderId);
-    }
-
-    [Fact]
-    public async Task GetEmailNotificationsByOrderId_DelegatesToClient_WithCorrectOrderId()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId("order-123")).ReturnsAsync(ValidOrderJson);
-
-        await _service.GetEmailNotificationsByOrderId("order-123");
-
-        _clientMock.Verify(c => c.GetEmailNotificationsByOrderId("order-123"), Times.Once);
-    }
-
-    [Fact]
-    public async Task GetEmailNotificationsByOrderId_ThrowsException_WhenClientThrows()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>()))
-            .ThrowsAsync(new Exception("API request failed"));
-
-        await Assert.ThrowsAsync<Exception>(() => _service.GetEmailNotificationsByOrderId("order-123"));
-    }
-
-    [Fact]
-    public async Task GetEmailNotificationsByOrderId_ThrowsJsonException_WhenResponseIsInvalidJson()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync("not-valid-json");
-
-        await Assert.ThrowsAsync<JsonException>(() => _service.GetEmailNotificationsByOrderId("order-123"));
-    }
-
-    [Fact]
-    public async Task GetEmailNotificationsByOrderId_ThrowsException_WhenResponseDeserializesToNull()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync("null");
-
-        await Assert.ThrowsAsync<Exception>(() => _service.GetEmailNotificationsByOrderId("order-123"));
-    }
-
-    [Fact]
-    public async Task GetSmsNotificationsByOrderId_ReturnsDeserializedResponse_WhenClientSucceeds()
-    {
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
-
-        var result = await _service.GetSmsNotificationsByOrderId("order-123");
-
-        Assert.Equal("order-123", result.OrderId);
-    }
-
-    [Fact]
-    public async Task GetSmsNotificationsByOrderId_DelegatesToClient_WithCorrectOrderId()
-    {
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId("order-123")).ReturnsAsync(ValidOrderJson);
-
-        await _service.GetSmsNotificationsByOrderId("order-123");
-
-        _clientMock.Verify(c => c.GetSmsNotificationsByOrderId("order-123"), Times.Once);
-    }
-
-    [Fact]
-    public async Task GetSmsNotificationsByOrderId_ThrowsException_WhenClientThrows()
-    {
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>()))
-            .ThrowsAsync(new Exception("API request failed"));
-
-        await Assert.ThrowsAsync<Exception>(() => _service.GetSmsNotificationsByOrderId("order-123"));
-    }
-
-    [Fact]
-    public async Task GetSmsNotificationsByOrderId_ThrowsJsonException_WhenResponseIsInvalidJson()
-    {
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync("not-valid-json");
-
-        await Assert.ThrowsAsync<JsonException>(() => _service.GetSmsNotificationsByOrderId("order-123"));
-    }
-
-    [Fact]
-    public async Task GetSmsNotificationsByOrderId_ThrowsException_WhenResponseDeserializesToNull()
-    {
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync("null");
-
-        await Assert.ThrowsAsync<Exception>(() => _service.GetSmsNotificationsByOrderId("order-123"));
-    }
-
-    // --- GetAllNotificationsByOrderId ---
-
-    [Fact]
-    public async Task GetAllNotificationsByOrderId_ReturnsBothResults_WhenBothCallsSucceed()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
-
-        var result = await _service.GetAllNotificationsByOrderId("order-123");
-
-        Assert.Equal(2, result.Count);
-    }
-
-    [Fact]
-    public async Task GetAllNotificationsByOrderId_ReturnsSingleResult_WhenEmailFails()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ThrowsAsync(new Exception("Email API failure"));
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
-
-        var result = await _service.GetAllNotificationsByOrderId("order-123");
-
-        Assert.Single(result);
-    }
-
-    [Fact]
-    public async Task GetAllNotificationsByOrderId_ReturnsSingleResult_WhenSmsFails()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ThrowsAsync(new Exception("SMS API failure"));
-
-        var result = await _service.GetAllNotificationsByOrderId("order-123");
-
-        Assert.Single(result);
-    }
-
-    [Fact]
-    public async Task GetAllNotificationsByOrderId_ThrowsError_WhenBothCallsFail()
-    {
-        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>())).ThrowsAsync(new Exception("Email API failure"));
-        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>())).ThrowsAsync(new Exception("SMS API failure"));
-
-        await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetAllNotificationsByOrderId("order-123"));
-    }
-
-    // --- GetFutureNotificationsByNin ---
 
     private const string ValidFutureNotificationsJson = """
         [
@@ -177,13 +36,156 @@ public class NotificationsServiceTests
         ]
         """;
 
+    public NotificationsServiceTests()
+    {
+        _clientMock = new Mock<INotificationsClient>();
+        var logger = Mock.Of<ILogger<INotificationsService>>();
+        _service = new NotificationsService(_clientMock.Object, logger);
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_ReturnsDeserializedResponse_WhenClientSucceeds()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+
+        var result = await _service.GetEmailNotificationsByOrderId("order-123", EnvironmentName);
+
+        Assert.Equal("order-123", result.OrderId);
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_DelegatesToClient_WithCorrectOrderId()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId("order-123", EnvironmentName)).ReturnsAsync(ValidOrderJson);
+
+        await _service.GetEmailNotificationsByOrderId("order-123", EnvironmentName);
+
+        _clientMock.Verify(c => c.GetEmailNotificationsByOrderId("order-123", EnvironmentName), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_ThrowsException_WhenClientThrows()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new Exception("API request failed"));
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetEmailNotificationsByOrderId("order-123", EnvironmentName));
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_ThrowsJsonException_WhenResponseIsInvalidJson()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("not-valid-json");
+
+        await Assert.ThrowsAsync<JsonException>(() => _service.GetEmailNotificationsByOrderId("order-123", EnvironmentName));
+    }
+
+    [Fact]
+    public async Task GetEmailNotificationsByOrderId_ThrowsException_WhenResponseDeserializesToNull()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("null");
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetEmailNotificationsByOrderId("order-123", EnvironmentName));
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_ReturnsDeserializedResponse_WhenClientSucceeds()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+
+        var result = await _service.GetSmsNotificationsByOrderId("order-123", EnvironmentName);
+
+        Assert.Equal("order-123", result.OrderId);
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_DelegatesToClient_WithCorrectOrderId()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId("order-123", EnvironmentName)).ReturnsAsync(ValidOrderJson);
+
+        await _service.GetSmsNotificationsByOrderId("order-123", EnvironmentName);
+
+        _clientMock.Verify(c => c.GetSmsNotificationsByOrderId("order-123", EnvironmentName), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_ThrowsException_WhenClientThrows()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new Exception("API request failed"));
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetSmsNotificationsByOrderId("order-123", EnvironmentName));
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_ThrowsJsonException_WhenResponseIsInvalidJson()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("not-valid-json");
+
+        await Assert.ThrowsAsync<JsonException>(() => _service.GetSmsNotificationsByOrderId("order-123", EnvironmentName));
+    }
+
+    [Fact]
+    public async Task GetSmsNotificationsByOrderId_ThrowsException_WhenResponseDeserializesToNull()
+    {
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("null");
+
+        await Assert.ThrowsAsync<Exception>(() => _service.GetSmsNotificationsByOrderId("order-123", EnvironmentName));
+    }
+
+    // --- GetAllNotificationsByOrderId ---
+
+    [Fact]
+    public async Task GetAllNotificationsByOrderId_ReturnsBothResults_WhenBothCallsSucceed()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+
+        var result = await _service.GetAllNotificationsByOrderId("order-123", EnvironmentName);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllNotificationsByOrderId_ReturnsSingleResult_WhenEmailFails()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(new Exception("Email API failure"));
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+
+        var result = await _service.GetAllNotificationsByOrderId("order-123", EnvironmentName);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task GetAllNotificationsByOrderId_ReturnsSingleResult_WhenSmsFails()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ValidOrderJson);
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(new Exception("SMS API failure"));
+
+        var result = await _service.GetAllNotificationsByOrderId("order-123", EnvironmentName);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task GetAllNotificationsByOrderId_ThrowsError_WhenBothCallsFail()
+    {
+        _clientMock.Setup(c => c.GetEmailNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(new Exception("Email API failure"));
+        _clientMock.Setup(c => c.GetSmsNotificationsByOrderId(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(new Exception("SMS API failure"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetAllNotificationsByOrderId("order-123", EnvironmentName));
+    }
+
+    // --- GetFutureNotificationsByNin ---
+
     [Fact]
     public async Task GetFutureNotificationsByNin_ReturnsDeserializedResponse_WhenClientSucceeds()
     {
-        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string>()))
             .ReturnsAsync(ValidFutureNotificationsJson);
 
-        var result = await _service.GetFutureNotificationsByNin("12345678901", null, null);
+        var result = await _service.GetFutureNotificationsByNin("12345678901", null, null, EnvironmentName);
 
         Assert.Single(result);
         Assert.Equal("test-creator", result[0].CreatorName);
@@ -194,38 +196,38 @@ public class NotificationsServiceTests
     {
         var from = new DateTime(2024, 1, 1);
         var to = new DateTime(2024, 2, 1);
-        _clientMock.Setup(c => c.GetFutureNotificationsByNin("12345678901", from, to))
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin("12345678901", from, to, EnvironmentName))
             .ReturnsAsync(ValidFutureNotificationsJson);
 
-        await _service.GetFutureNotificationsByNin("12345678901", from, to);
+        await _service.GetFutureNotificationsByNin("12345678901", from, to, EnvironmentName);
 
-        _clientMock.Verify(c => c.GetFutureNotificationsByNin("12345678901", from, to), Times.Once);
+        _clientMock.Verify(c => c.GetFutureNotificationsByNin("12345678901", from, to, EnvironmentName), Times.Once);
     }
 
     [Fact]
     public async Task GetFutureNotificationsByNin_ThrowsException_WhenClientThrows()
     {
-        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string>()))
             .ThrowsAsync(new Exception("API request failed"));
 
-        await Assert.ThrowsAsync<Exception>(() => _service.GetFutureNotificationsByNin("12345678901", null, null));
+        await Assert.ThrowsAsync<Exception>(() => _service.GetFutureNotificationsByNin("12345678901", null, null, EnvironmentName));
     }
 
     [Fact]
     public async Task GetFutureNotificationsByNin_ThrowsJsonException_WhenResponseIsInvalidJson()
     {
-        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string>()))
             .ReturnsAsync("not-valid-json");
 
-        await Assert.ThrowsAsync<JsonException>(() => _service.GetFutureNotificationsByNin("12345678901", null, null));
+        await Assert.ThrowsAsync<JsonException>(() => _service.GetFutureNotificationsByNin("12345678901", null, null, EnvironmentName));
     }
 
     [Fact]
     public async Task GetFutureNotificationsByNin_ThrowsException_WhenResponseDeserializesToNull()
     {
-        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+        _clientMock.Setup(c => c.GetFutureNotificationsByNin(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string>()))
             .ReturnsAsync("null");
 
-        await Assert.ThrowsAsync<Exception>(() => _service.GetFutureNotificationsByNin("12345678901", null, null));
+        await Assert.ThrowsAsync<Exception>(() => _service.GetFutureNotificationsByNin("12345678901", null, null, EnvironmentName));
     }
 }

--- a/frontend/altinn-support-dashboard.client/package-lock.json
+++ b/frontend/altinn-support-dashboard.client/package-lock.json
@@ -7893,24 +7893,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationCard.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationCard.tsx
@@ -20,7 +20,7 @@ const NotificationCard: React.FC<NotificationCardProps> = ({ order }) => {
       <Heading level={2} data-size="xs">
         {getType()}
       </Heading>
-      <Paragraph>Order id: {order.orderId}</Paragraph>
+      <Paragraph>Shipment id: {order.orderId}</Paragraph>
       <Paragraph>Avsenders referanse: {order.sendersReference}</Paragraph>
       <Paragraph>Generert: {order.generated}</Paragraph>
       <Paragraph>Vellykket: {order.succeeded}</Paragraph>

--- a/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationSearchBar.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Notification/NotificationSearchBar.tsx
@@ -20,8 +20,8 @@ const NotificationSearchBar: React.FC<NotificationSearchBarProps> = ({
   return (
     <div className={style.container}>
       <Textfield
-        label="Order ID"
-        placeholder="Skriv inn ordre-id"
+        label="Shipment ID"
+        placeholder="Skriv inn shipment-id"
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         onKeyDown={(e) => {

--- a/frontend/altinn-support-dashboard.client/src/hooks/hooks.ts
+++ b/frontend/altinn-support-dashboard.client/src/hooks/hooks.ts
@@ -162,10 +162,10 @@ export function useInternalIdLookup(query: string, environment: string) {
   });
 }
 
-export function useNotifications(orderId: string) {
+export function useNotifications(orderId: string, environment: string) {
   const notificationQuery = useQuery({
-    queryKey: ["notifications", orderId],
-    queryFn: () => fetchNotificationByOrderId(orderId),
+    queryKey: ["notifications", orderId, environment],
+    queryFn: () => fetchNotificationByOrderId(orderId, environment),
     enabled: !!orderId,
     retry: false,
     staleTime: 2 * 60 * 1000,
@@ -186,7 +186,10 @@ export function useResourceSearch(environment: string, query: string) {
   return { resourceQuery };
 }
 
-export function useResourceWithPolicies(environment: string, identifier?: string) {
+export function useResourceWithPolicies(
+  environment: string,
+  identifier?: string
+) {
   const resourceQuery = useQuery<Resource | null, Error>({
     queryKey: ["resource", environment, identifier],
     queryFn: () => fetchResourceByIdentifier(environment, identifier!),
@@ -196,7 +199,7 @@ export function useResourceWithPolicies(environment: string, identifier?: string
     refetchOnWindowFocus: false,
   });
 
-    const policyRulesQuery = useQuery<PolicyRule[], Error>({
+  const policyRulesQuery = useQuery<PolicyRule[], Error>({
     queryKey: ["policyRules", environment, identifier],
     queryFn: () => fetchResourcePolicyRules(environment, identifier!),
     enabled: !!identifier,

--- a/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/NotificationPage.tsx
@@ -5,10 +5,12 @@ import { useNotifications } from "../hooks/hooks";
 import NotificationCard from "../components/Notification/NotificationCard";
 import style from "./styles/NotificationPage.module.css";
 import { showPopup } from "../components/Popup";
+import { useAppStore } from "../stores/Appstore";
 
 export const NotificationPage = () => {
   const [orderId, setOrderId] = useState("");
-  const notificationQuery = useNotifications(orderId);
+  const environment = useAppStore((state) => state.environment);
+  const notificationQuery = useNotifications(orderId, environment);
 
   useEffect(() => {
     if (notificationQuery.isError) {

--- a/frontend/altinn-support-dashboard.client/src/utils/api.ts
+++ b/frontend/altinn-support-dashboard.client/src/utils/api.ts
@@ -2,7 +2,12 @@ import { authorizedFetch, authorizedPost, getBaseUrl } from "./utils";
 import { NotificationAdresses, PersonalContactAltinn3 } from "../models/models";
 import { RolesAndRights, RolesAndRightsRequest } from "../models/rolesModels";
 import { NotificationOrderResponse } from "../models/notificationModels";
-import { Altinn2Role, PolicyRule, Resource, ResourceSearchResult } from "../models/resourceModels";
+import {
+  Altinn2Role,
+  PolicyRule,
+  Resource,
+  ResourceSearchResult,
+} from "../models/resourceModels";
 import { PartyModel } from "../models/PartyModel";
 
 //this file defines which which api endpoints we want to fetch data from
@@ -114,10 +119,11 @@ export const fetchNotificationAddresses = async (
 };
 
 export const fetchNotificationByOrderId = async (
-  orderId: string
+  orderId: string,
+  environment: string
 ): Promise<NotificationOrderResponse[] | null> => {
   const res = await authorizedFetch(
-    `/api/notifications/orderid/${encodeURIComponent(orderId)}`
+    `/api/${environment}/notifications/orderid/${encodeURIComponent(orderId)}`
   );
 
   if (res.status === 404) return null;
@@ -134,28 +140,32 @@ export const fetchResources = async (
   query: string
 ): Promise<ResourceSearchResult[]> => {
   const res = await authorizedFetch(
-    `${getBaseUrl(environment)}/resource/search?resourceTitle=${encodeURIComponent(query)}`,
+    `${getBaseUrl(environment)}/resource/search?resourceTitle=${encodeURIComponent(query)}`
   );
 
   if (res.status === 404) return [];
-  if (!res.ok) throw new Error((await res.text()) || "Error fetching resources");
+  if (!res.ok)
+    throw new Error((await res.text()) || "Error fetching resources");
 
   const data = await res.json();
   return Array.isArray(data) ? data : [data];
-}
+};
 
 export const fetchResourceByIdentifier = async (
   environment: string,
-  identifier: string,
+  identifier: string
 ): Promise<Resource | null> => {
   const res = await authorizedFetch(
-    `${getBaseUrl(environment)}/resource/${encodeURIComponent(identifier)}`,
+    `${getBaseUrl(environment)}/resource/${encodeURIComponent(identifier)}`
   );
 
   if (res.status === 404) return null;
-  if (!res.ok) throw new Error((await res.text()) || "Error fetching resource by identifier");
+  if (!res.ok)
+    throw new Error(
+      (await res.text()) || "Error fetching resource by identifier"
+    );
   return await res.json();
-}
+};
 
 export const fetchResourcePolicyRules = async (
   environment: string,
@@ -165,13 +175,19 @@ export const fetchResourcePolicyRules = async (
     `${getBaseUrl(environment)}/resource/${encodeURIComponent(identifier)}/policy/rules`
   );
   if (res.status === 404) return [];
-  if (!res.ok) throw new Error((await res.text()) || "Error fetching policy rules");
+  if (!res.ok)
+    throw new Error((await res.text()) || "Error fetching policy rules");
   const data = await res.json();
   return Array.isArray(data) ? data : [];
-}
-export const fetchRoleDefinitions = async (environment: string): Promise<Altinn2Role[]> => {
-  const res = await authorizedFetch(`${getBaseUrl(environment)}/serviceowner/rolesList`);
-  if (!res.ok) throw new Error((await res.text()) || "Error fetching role definitions");
+};
+export const fetchRoleDefinitions = async (
+  environment: string
+): Promise<Altinn2Role[]> => {
+  const res = await authorizedFetch(
+    `${getBaseUrl(environment)}/serviceowner/rolesList`
+  );
+  if (!res.ok)
+    throw new Error((await res.text()) || "Error fetching role definitions");
   return await res.json();
 };
 

--- a/frontend/altinn-support-dashboard.client/test/Notifications/NotificationCard.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Notifications/NotificationCard.test.tsx
@@ -18,7 +18,7 @@ describe("NotificationOrderSummary", () => {
     it("should render order details", () => {
         render(<NotificationCard order={baseOrder} />);
 
-        expect(screen.getByText("Order id: abc-123")).toBeInTheDocument();
+        expect(screen.getByText("Shipment id: abc-123")).toBeInTheDocument();
         expect(screen.getByText("Avsenders referanse: ref-456")).toBeInTheDocument();
         expect(screen.getByText("Generert: 3")).toBeInTheDocument();
         expect(screen.getByText("Vellykket: 2")).toBeInTheDocument();

--- a/frontend/altinn-support-dashboard.client/test/Notifications/NotificationSearchBar.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Notifications/NotificationSearchBar.test.tsx
@@ -8,7 +8,7 @@ describe("NotificationSearchBar", () => {
     it("should render input and buttons", () => {
         render(<NotificationSearchBar orderId="" setOrderId={vi.fn()} />);
 
-        expect(screen.getByPlaceholderText("Skriv inn ordre-id")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("Skriv inn shipment-id")).toBeInTheDocument();
         expect(screen.getByText("x")).toBeInTheDocument();
     });
 
@@ -16,7 +16,7 @@ describe("NotificationSearchBar", () => {
         render(<NotificationSearchBar orderId="" setOrderId={vi.fn()} />);
         const user = userEvent.setup();
 
-        const input = screen.getByPlaceholderText("Skriv inn ordre-id");
+        const input = screen.getByPlaceholderText("Skriv inn shipment-id");
         await user.type(input, "abc-123");
 
         expect(input).toHaveValue("abc-123");
@@ -27,7 +27,7 @@ describe("NotificationSearchBar", () => {
         render(<NotificationSearchBar orderId="" setOrderId={setOrderId} />);
         const user = userEvent.setup();
 
-        const input = screen.getByPlaceholderText("Skriv inn ordre-id");
+        const input = screen.getByPlaceholderText("Skriv inn shipment-id");
         await user.type(input, "order-42");
         const buttons = screen.getAllByRole("button");
         await user.click(buttons[0]);
@@ -40,7 +40,7 @@ describe("NotificationSearchBar", () => {
         render(<NotificationSearchBar orderId="" setOrderId={setOrderId} />);
         const user = userEvent.setup();
 
-        const input = screen.getByPlaceholderText("Skriv inn ordre-id");
+        const input = screen.getByPlaceholderText("Skriv inn shipment-id");
         await user.type(input, "order-99{Enter}");
 
         expect(setOrderId).toHaveBeenCalledWith("order-99");
@@ -51,7 +51,7 @@ describe("NotificationSearchBar", () => {
         render(<NotificationSearchBar orderId="" setOrderId={setOrderId} />);
         const user = userEvent.setup();
 
-        const input = screen.getByPlaceholderText("Skriv inn ordre-id");
+        const input = screen.getByPlaceholderText("Skriv inn shipment-id");
         await user.type(input, "some-value");
         await user.click(screen.getByText("x"));
 
@@ -62,6 +62,6 @@ describe("NotificationSearchBar", () => {
     it("should initialize input with provided orderId", () => {
         render(<NotificationSearchBar orderId="existing-id" setOrderId={vi.fn()} />);
 
-        expect(screen.getByPlaceholderText("Skriv inn ordre-id")).toHaveValue("existing-id");
+        expect(screen.getByPlaceholderText("Skriv inn shipment-id")).toHaveValue("existing-id");
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new endpoint to fetch future scheduled notifications for a given       
national identity number (NIN).

Changes:
- New GET /api/{env}/notifications/future/nin/{nin} endpoint with optional    
from/to query parameters
- Added models: FutureNotificationDto, FutureNotificationDeliveryAttemptDto   
- Client and service wired up for both TT02 and prod environments
- Tests added for controller and service




