### PR TITLE
Different file type in correspondence

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
@@ -1,10 +1,12 @@
 using System.Globalization;
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using altinn_support_dashboard.Server.Models;
 using altinn_support_dashboard.Server.Models.correspondence;
+using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
@@ -98,22 +100,35 @@ public class CorrespondenceClient : ICorrespondenceClient
 
         //Attachments
         //In the future we might add the ability to upload custom attachments
-        var content = "This is a test attachment";
-        var bytes = Encoding.UTF8.GetBytes(content);
 
-        var fileContent = new ByteArrayContent(bytes);
-        fileContent.Headers.ContentType =
-            new MediaTypeHeaderValue("text/plain");
-        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-        form.Add(fileContent, "Attachments", "testfile.txt");
-        form.Add(
-            new StringContent("testfile-1"),
-            "correspondence.content.attachments[0].sendersReference"
-        );
-        form.Add(
-            new StringContent("testfile.txt"),
-            "correspondence.content.attachments[0].filename"
-        );
+        if(correspondenceData.Correspondence.AttachmentType == "zip")
+        {
+            var zipStream = new MemoryStream();
+            using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var entry = archive.CreateEntry("testfile.txt");
+                using var entryStream = entry.Open();
+                var textBytes = Encoding.UTF8.GetBytes("This is a test attachment");
+                entryStream.Write(textBytes, 0, textBytes.Length);
+            }
+            zipStream.Position = 0;
+            var fileContent = new ByteArrayContent(zipStream.ToArray());
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+            form.Add(fileContent, "Attachments", "testfile.zip");
+            form.Add(new StringContent("testfile-1"), "correspondence.content.attachments[0].sendersReferance");
+            form.Add(new StringContent("testfile.zip"), "correspondence.content.attachments[0].filename");
+        }
+        else
+        {
+            var bytes = Encoding.UTF8.GetBytes("This is a test attachment");
+            var fileContent = new ByteArrayContent(bytes);
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue("");
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+            form.Add(fileContent, "Attachments", "testfile.txt");
+            form.Add(new StringContent("testfile-1"), "correspondence.content.attachments[0].sendersReferance");
+            form.Add(new StringContent("testfile.txt"), "correspondence.content.attachments[0].filename");
+        }
+        
 
         var request = new HttpRequestMessage(HttpMethod.Post, requestUrl);
         request.Content = form;

--- a/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
@@ -118,17 +118,16 @@ public class CorrespondenceClient : ICorrespondenceClient
             var fileContent = new ByteArrayContent(zipStream.ToArray());
             fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
             form.Add(fileContent, "Attachments", "testfile.zip");
-            form.Add(new StringContent("testfile-1"), "correspondence.content.attachments[0].sendersReferance");
+            form.Add(new StringContent("testfile-1"), "correspondence.content.attachments[0].sendersreference");
             form.Add(new StringContent("testfile.zip"), "correspondence.content.attachments[0].filename");
         }
         else
         {
             var bytes = Encoding.UTF8.GetBytes("This is a test attachment");
             var fileContent = new ByteArrayContent(bytes);
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("");
             fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
             form.Add(fileContent, "Attachments", "testfile.txt");
-            form.Add(new StringContent("testfile-1"), "correspondence.content.attachments[0].sendersReferance");
+            form.Add(new StringContent("testfile-1"), "correspondence.content.attachments[0].sendersreference");
             form.Add(new StringContent("testfile.txt"), "correspondence.content.attachments[0].filename");
         }
         

--- a/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
@@ -104,7 +104,7 @@ public class CorrespondenceClient : ICorrespondenceClient
         //Attachments
         //In the future we might add the ability to upload custom attachments
 
-        if(correspondenceData.Correspondence?.AttachmentType == "zip")
+        if(correspondenceData?.Correspondence?.AttachmentType == "zip")
         {
             var zipStream = new MemoryStream();
             using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))

--- a/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/CorrespondenceClient.cs
@@ -104,7 +104,7 @@ public class CorrespondenceClient : ICorrespondenceClient
         //Attachments
         //In the future we might add the ability to upload custom attachments
 
-        if(correspondenceData.Correspondence.AttachmentType == "zip")
+        if(correspondenceData.Correspondence?.AttachmentType == "zip")
         {
             var zipStream = new MemoryStream();
             using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))

--- a/backend/src/altinn-support-dashboard.backend/Models/correspondence/Correspondence.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/correspondence/Correspondence.cs
@@ -23,5 +23,6 @@ public class Correspondence
     public DateTime? Published { get; set; }
     public bool? IsConfirmationNeeded { get; set; }
     public bool? IsConfidential { get; set; }
+    public string AttachmentType { get; set; } = "txt";
 }
 

--- a/backend/test/altinn-support-dashboard.backend.Tests/Services/CorrespondenceServiceTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Services/CorrespondenceServiceTests.cs
@@ -142,4 +142,29 @@ public class CorrespondenceServiceTests
         Assert.Contains("Need at least one Recipient", ex.Message);
         _clientMock.Verify(c => c.UploadCorrespondence(It.IsAny<CorrespondenceUploadRequest>()), Times.Never);
     }
+
+    [Theory]
+    [InlineData("txt")]
+    [InlineData("zip")]
+    public async Task UploadCorrespondence_AttachmentType_IsPassedThroughToClient(string attachmentType)
+    {
+        var request = new CorrespondenceUploadRequest
+        {
+            Recipients = new List<string> { "123456789" },
+            Correspondence = new Correspondence { AttachmentType = attachmentType }
+        };
+
+        _clientMock
+            .Setup(c => c.UploadCorrespondence(It.IsAny<CorrespondenceUploadRequest>()))
+            .ReturnsAsync(new CorrespondenceResponse());
+
+        await _service.UploadCorrespondence(request);
+
+        _clientMock.Verify(c =>
+            c.UploadCorrespondence(It.Is<CorrespondenceUploadRequest>(r =>
+                r.Correspondence.AttachmentType == attachmentType
+            )),
+            Times.Once
+        );
+    }
 }

--- a/frontend/altinn-support-dashboard.client/src/components/Correspondence/CorrespondenceButton.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Correspondence/CorrespondenceButton.tsx
@@ -13,6 +13,7 @@ type CorrespondenceButtonProps = {
   summary: string;
   body: string;
   confirmationNeeded: boolean;
+  attachmentType: "txt" | "zip";
   notificationChannel: NotificationChannel;
 
   setResponseMessage: (responseData: CorrespondenceResponse) => void;
@@ -27,6 +28,7 @@ const CorrespondenceButton: React.FC<CorrespondenceButtonProps> = ({
   summary,
   body,
   confirmationNeeded,
+  attachmentType,
   setResponseMessage,
   dueDate,
 }) => {
@@ -45,6 +47,7 @@ const CorrespondenceButton: React.FC<CorrespondenceButtonProps> = ({
         resourceType: resourceType,
         isConfirmationNeeded: confirmationNeeded,
         dueDateTime: dueDate || undefined,
+        attachmentType: attachmentType,
       },
     };
     //sets notification options

--- a/frontend/altinn-support-dashboard.client/src/models/correspondenceModels.ts
+++ b/frontend/altinn-support-dashboard.client/src/models/correspondenceModels.ts
@@ -8,6 +8,7 @@ export interface Correspondence {
   notification?: CorrespondenceNotification;
   isConfirmationNeeded?: boolean;
   dueDateTime?: string;
+  attachmentType?: "txt" | "zip";
 }
 
 export interface CorrespondenceContent {

--- a/frontend/altinn-support-dashboard.client/src/pages/CorrespondencePage.tsx
+++ b/frontend/altinn-support-dashboard.client/src/pages/CorrespondencePage.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Heading, Label } from "@digdir/designsystemet-react";
+import { Checkbox, Heading, Label, Select } from "@digdir/designsystemet-react";
 import classes from "./styles/CorrespondencePage.module.css";
 import { useState } from "react";
 import {
@@ -56,6 +56,9 @@ export const CorrespondencePage = () => {
     setConfirmationNeeded(bool);
     setLocalStorageValue("confirmationNeeded", JSON.stringify(bool));
   };
+
+  const [attachmentType, setAttachmentType] = useState<"txt" | "zip">("txt");
+
   return (
     <div>
       <Heading className={classes.heading} level={1} data-size="sm">
@@ -118,6 +121,11 @@ export const CorrespondencePage = () => {
             SelectedDateTime={selectedDateTime}
             SetSelectedDateTime={setSelectedDateTime}
           />
+          <Label>Vedleggstype</Label>
+          <Select value={attachmentType} onChange={(e) => setAttachmentType(e.target.value as "txt" | "zip")}>
+            <Select.Option value="txt">.txt</Select.Option>
+            <Select.Option value="zip">.zip</Select.Option>
+          </Select>
           <CorrespondenceButton
             resourceType={resourceType}
             dueDate={selectedDateTime}
@@ -127,6 +135,7 @@ export const CorrespondencePage = () => {
             body={body}
             confirmationNeeded={confirmationNeeded}
             notificationChannel={notificationChannel}
+            attachmentType={attachmentType}
             setResponseMessage={setResponseMessage}
           />
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for choosing the attachment file type when sending a correspondence message. Previously the attachment was always a .txt file; users can now select between .txt and .zip.

- Frontend: Added a "Vedleggstype" dropdown (.txt / .zip) to CorrespondencePage, wired the selection through CorrespondenceButton props and the Correspondence model.
- Backend model: Added AttachmentType property (defaults to "txt") to the Correspondence model.
- Backend logic: Updated CorrespondenceClient to branch on AttachmentType — for zip, it packages the test content into a ZipArchive in memory and sends it as application/zip; for txt, it sends the plain text file as before.


## Related Issue(s)
- #749 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
