### PR TITLE
Fix incorrect "Fratrådt" status in ER-roller — use correct avregistrert field from BRREG

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Clients/Mocks/Data/brreg-roles.json
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Mocks/Data/brreg-roles.json
@@ -11,7 +11,7 @@
             "navn": { "fornavn": "Test", "mellomnavn": null, "etternavn": "Testesen" },
             "erDoed": false
           },
-          "fratraadt": false,
+          "avreegistrert": false,
           "rekkefolge": 1
         }
       ]

--- a/backend/src/altinn-support-dashboard.backend/Clients/Mocks/Data/brreg-roles.json
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Mocks/Data/brreg-roles.json
@@ -11,7 +11,7 @@
             "navn": { "fornavn": "Test", "mellomnavn": null, "etternavn": "Testesen" },
             "erDoed": false
           },
-          "avreegistrert": false,
+          "avregistrert": false,
           "rekkefolge": 1
         }
       ]

--- a/backend/src/altinn-support-dashboard.backend/Models/ErRollerModel.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/ErRollerModel.cs
@@ -43,7 +43,7 @@
         public Type? Type { get; set; }
         public Enhet? Enhet { get; set; }
         public Person? Person { get; set; }
-        public bool Fratraadt { get; set; }
+        public bool Avregistrert { get; set; }
         public int Rekkefolge { get; set; }
     }
 

--- a/frontend/altinn-support-dashboard.client/e2e/fixtures.ts
+++ b/frontend/altinn-support-dashboard.client/e2e/fixtures.ts
@@ -37,7 +37,7 @@ const mockERoles = {
                         navn: { fornavn: "Test", mellomnavn: null, etternavn: "Person" },
                         erDoed: false
                     },
-                    fratraadt: false
+                    avregistrert: false
                 }
             ]
         }

--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/ERRolesTable.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/ERRolesTable.tsx
@@ -52,7 +52,7 @@ const ERRolesTable: React.FC<ERRolesTableProps> = ({ selectedOrg }) => {
     for (const rolegroup of rolegroups) {
       for (const role of rolegroup.roller) {
         erRoleItems.push({
-          fratraadt: role.fratraadt,
+          avregistrert: role.avregistrert,
           sistEndret: rolegroup.sistEndret,
           type: role.type,
           enhet: role.enhet,
@@ -127,7 +127,7 @@ const ERRolesTable: React.FC<ERRolesTableProps> = ({ selectedOrg }) => {
                     : role?.person?.fodselsdato}
                 </Table.Cell>
                 <Table.Cell className={styles["cell-font"]}>
-                  {role.fratraadt ? "Fratrådt" : "Aktiv"}
+                  {role.avregistrert ? "Avregistrert" : "Aktiv"}
                   {role.person?.erDoed ? " (Død)" : ""}
                   {role.enhet?.erSlettet ? " (Slettet)" : ""}
                 </Table.Cell>

--- a/frontend/altinn-support-dashboard.client/src/models/models.ts
+++ b/frontend/altinn-support-dashboard.client/src/models/models.ts
@@ -55,7 +55,7 @@ export interface ErRole {
   type: ErType;
   person: person;
   enhet?: enhet;
-  fratraadt: boolean;
+  avregistrert: boolean;
   rekkefolge?: number;
 }
 
@@ -88,8 +88,7 @@ export interface ErRoleTableItem {
   type: ErType;
   enhet?: enhet;
   person?: person;
-  fratraadt: boolean;
-
+  avregistrert: boolean;
   groupType: ErType;
 }
 

--- a/frontend/altinn-support-dashboard.client/test/Dashboard/components/ERRolesTable.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Dashboard/components/ERRolesTable.test.tsx
@@ -76,7 +76,7 @@ describe("ERRolesTable", () => {
             navn: { fornavn: "Test", mellomnavn: "", etternavn: "User" },
             erDoed: false,
           },
-          fratraadt: false,
+          avregistrert: false,
         },
       ],
     },
@@ -135,7 +135,7 @@ describe("ERRolesTable", () => {
               organisasjonsform: { kode: "AS", beskrivelse: "Aksjeselskap" },
               erSlettet: false,
             },
-            fratraadt: false,
+            avregistrert: false,
           },
         ],
       },
@@ -153,7 +153,7 @@ describe("ERRolesTable", () => {
     expect(screen.getByText("Test Company (987654321)")).toBeInTheDocument();
   });
 
-  it('should display "Fratrådt" status for inactive roles', () => {
+  it('should display "Avregistrert" status for inactive roles', () => {
     const inactiveRole: ERRoles[] = [
       {
         type: { kode: "ERole", beskrivelse: "ERole" },
@@ -165,7 +165,7 @@ describe("ERRolesTable", () => {
               navn: { fornavn: "Inactive", mellomnavn: "", etternavn: "User" },
               erDoed: false,
             },
-            fratraadt: true,
+            avregistrert: true,
           },
         ],
       },
@@ -180,7 +180,7 @@ describe("ERRolesTable", () => {
 
     render(<ERRolesTable selectedOrg={mockSelectedOrg} />);
 
-    expect(screen.getByText("Fratrådt")).toBeInTheDocument();
+    expect(screen.getByText("Avregistrert")).toBeInTheDocument();
   });
 
   it('should display "Død" for deceased persons', () => {
@@ -195,7 +195,7 @@ describe("ERRolesTable", () => {
               navn: { fornavn: "Deceased", mellomnavn: "", etternavn: "User" },
               erDoed: true,
             },
-            fratraadt: false,
+            avregistrert: false,
           },
         ],
       },
@@ -229,7 +229,7 @@ describe("ERRolesTable", () => {
               organisasjonsform: { kode: "AS", beskrivelse: "Aksjeselskap" },
               erSlettet: true,
             },
-            fratraadt: false,
+            avregistrert: false,
           },
         ],
       },

--- a/frontend/altinn-support-dashboard.client/test/Dashboard/utils/contactUtils.test.ts
+++ b/frontend/altinn-support-dashboard.client/test/Dashboard/utils/contactUtils.test.ts
@@ -111,8 +111,8 @@ describe('contactUtils', () => {
 
     describe('sortERRoles', () => {
         const mockRoles: ErRoleTableItem[] = [
-            { type: { beskrivelse: 'Daglig leder', kode: 'DL' }, person: { navn: { fornavn: 'Ola', mellomnavn: '', etternavn: 'Nordmann' }, erDoed: false }, sistEndret: '2025-12-31', fratraadt: false, groupType: { beskrivelse: 'Type1', kode: 'T1' } },
-            { type: { beskrivelse: 'Styremedlem', kode: 'SM' }, person: { navn: { fornavn: 'Kari', mellomnavn: '', etternavn: 'Nord' }, erDoed: false }, sistEndret: '2026-12-31', fratraadt: false, groupType: { beskrivelse: 'Type2', kode: 'T2' } },
+            { type: { beskrivelse: 'Daglig leder', kode: 'DL' }, person: { navn: { fornavn: 'Ola', mellomnavn: '', etternavn: 'Nordmann' }, erDoed: false }, sistEndret: '2025-12-31', avregistrert: false, groupType: { beskrivelse: 'Type1', kode: 'T1' } },
+            { type: { beskrivelse: 'Styremedlem', kode: 'SM' }, person: { navn: { fornavn: 'Kari', mellomnavn: '', etternavn: 'Nord' }, erDoed: false }, sistEndret: '2026-12-31', avregistrert: false, groupType: { beskrivelse: 'Type2', kode: 'T2' } },
         ];
 
         it('should return unsorted roles when sortField is null', () => {
@@ -158,8 +158,8 @@ describe('contactUtils', () => {
 
         it('should handle roles with missing fields', () => {
             const rolesWithMissingFields: ErRoleTableItem[] = [
-                { type: { beskrivelse: '', kode: '' }, person: { navn: { fornavn: '', mellomnavn: '', etternavn: '' }, erDoed: false }, sistEndret: '', fratraadt: false, groupType: { beskrivelse: '', kode: '' } },
-                { type: { beskrivelse: 'Valid Type', kode: 'VT' }, person: { navn: { fornavn: 'Valid', mellomnavn: '', etternavn: 'Person' }, erDoed: false }, sistEndret: '2026-01-01', fratraadt: false, groupType: { beskrivelse: 'Type3', kode: 'T3' } }
+                { type: { beskrivelse: '', kode: '' }, person: { navn: { fornavn: '', mellomnavn: '', etternavn: '' }, erDoed: false }, sistEndret: '', avregistrert: false, groupType: { beskrivelse: '', kode: '' } },
+                { type: { beskrivelse: 'Valid Type', kode: 'VT' }, person: { navn: { fornavn: 'Valid', mellomnavn: '', etternavn: 'Person' }, erDoed: false }, sistEndret: '2026-01-01', avregistrert: false, groupType: { beskrivelse: 'Type3', kode: 'T3' } }
             ];
             const result = sortERRoles(rolesWithMissingFields, 'type', "ascending");
             expect(result).toEqual([rolesWithMissingFields[0], rolesWithMissingFields[1]]);

--- a/frontend/altinn-support-dashboard.client/test/Dashboard/utils/personUtils.test.ts
+++ b/frontend/altinn-support-dashboard.client/test/Dashboard/utils/personUtils.test.ts
@@ -69,7 +69,7 @@ describe('formatRolePersonInfo', () => {
                     navn: { fornavn: "Ole", mellomnavn: null, etternavn: "Hansen" },
                 erDoed: false
                 },
-                fratraadt: false
+                avregistrert: false
             }]
         };
         expect(formatRolePersonInfo(role)).toBe('Ole Hansen');
@@ -86,7 +86,7 @@ describe('formatRolePersonInfo', () => {
                     navn: { fornavn: "Ole", mellomnavn: null, etternavn: "Hansen" },
                     erDoed: true
                 },
-                fratraadt: false
+                avregistrert: false
             }]
         };
         expect(formatRolePersonInfo(role)).toBe('Ole Hansen (Død)');
@@ -109,7 +109,7 @@ describe('formatRolePersonInfo', () => {
                 type: { kode: "DAGL", beskrivelse: "Daglig leder" },
                 //eslint-disable-next-line @typescript-eslint/no-explicit-any
                 person: undefined as any,
-                fratraadt: false
+                avregistrert: false
             }]
         };
         expect(formatRolePersonInfo(role)).toBe('');
@@ -160,7 +160,7 @@ describe('formatRoleDescription', () => {
                     navn: { fornavn: "Ole", mellomnavn: null, etternavn: "Hansen" },
                     erDoed: false
                 },
-                fratraadt: false
+                avregistrert: false
             }]
         };
         expect(formatRoleDescription(role)).toBe('Daglig leder: Ole Hansen');
@@ -177,7 +177,7 @@ describe('formatRoleDescription', () => {
                     navn: { fornavn: "Ole", mellomnavn: null, etternavn: "Hansen" },
                     erDoed: true
                 },
-                fratraadt: false
+                avregistrert: false
             }]
         };
         expect(formatRoleDescription(role)).toBe('Daglig leder: Ole Hansen (Død)');
@@ -204,7 +204,7 @@ describe('formatRoleDescription', () => {
                     navn: { fornavn: "Ole", mellomnavn: null, etternavn: "Hansen" },
                     erDoed: false
                 },
-                fratraadt: false
+                avregistrert: false
             }]
         };
         expect(formatRoleDescription(role)).toBe(': Ole Hansen');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The ER-roller status column always displayed "Aktiv", even for roles that had actually been terminated.

### Root cause

The backend Roller model expected a JSON field called fratraadt, but the real Enhetsregisteret API `(/enhetsregisteret/api/enheter/{orgnr}/roller)` returns this field as `avregistrert`. Since System.Text.Json silently drops unmatched properties,` Fratraad`t always deserialized to `false`, and the frontend's "Fratrådt" branch could never trigger.

### Changes

- `ErRollerModel.cs`: renamed `Roller.Fratraadt` → `Roller.Avregistrert` to match the real BRREG field name
- `models.ts`: renamed `ErRole.fratraadt `/` ErRoleTableItem.fratraadt` → `avregistrert`
- `ERRolesTable.tsx`: reads `role.avregistrert` and now displays "Avregistrert" instead of "Fratrådt" for terminated roles
- Updated all affected tests (`ERRolesTable.test.tsx`, `personUtils.test.ts`, `contactUtils.test.ts`) and the e2e fixture (`fixtures.ts`) to use the new field name
- Updated the mock BRREG response used in dev/testing (`brreg-roles.json`)

## Related Issue(s)
- #775 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
