### PR TITLE
776 make new generic developer role in azure

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Controllers/AltinnPartyController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/AltinnPartyController.cs
@@ -8,7 +8,7 @@ using Security;
 namespace altinn_support_dashboard.Server.Controllers
 {
     [ApiController]
-    [Authorize(AzureRoles.CoreExternal)]
+    [Authorize(AzureRoles.Developer)]
     [Route("api/TT02")]
     public class AltinnPartyTT02Controller : AltinnPartyBaseController
     {
@@ -16,7 +16,7 @@ namespace altinn_support_dashboard.Server.Controllers
     }
 
     [ApiController]
-    [Authorize(AzureRoles.CoreExternal)]
+    [Authorize(AzureRoles.Developer)]
     [Route("api/Production")]
     public class AltinnPartyProductionController : AltinnPartyBaseController
     {

--- a/backend/src/altinn-support-dashboard.backend/Security/AzureEntra/AzureAuthorizationExtensions.cs
+++ b/backend/src/altinn-support-dashboard.backend/Security/AzureEntra/AzureAuthorizationExtensions.cs
@@ -65,6 +65,10 @@ public static class AzureAuthorizationExtensions
             {
                 if (enabled) p.RequireAssertion(ctx => HasRole(ctx.User, AzureRoles.TT02));
                 else p.RequireAssertion(_ => true);
+            }).AddPolicy(AzureRoles.Developer, p =>
+            {
+                if (enabled) p.RequireAssertion(ctx => HasRole(ctx.User, AzureRoles.Developer));
+                else p.RequireAssertion(_ => true);
             })
             .AddPolicy(AzureRoles.CoreInternal, p =>
             {

--- a/backend/src/altinn-support-dashboard.backend/Security/AzureEntra/AzureRoles.cs
+++ b/backend/src/altinn-support-dashboard.backend/Security/AzureEntra/AzureRoles.cs
@@ -5,6 +5,7 @@ public static class AzureRoles
     public const string Authenticated = "AzureAuthenticated";
     public const string TT02 = "Dashboard.TT02";
     public const string Production = "Dashboard.PROD";
+    public const string Developer = "Dashboard.Developer";
     public const string CoreInternal = "Dashboard.Core.Internal";
     public const string CoreExternal = "Dashboard.Core.External";
 }

--- a/backend/src/altinn-support-dashboard.backend/appsettings.json
+++ b/backend/src/altinn-support-dashboard.backend/appsettings.json
@@ -85,7 +85,7 @@
 
   "FeatureManagement": {
     "Ansattporten": false,
-    "AzureEntra": false,
+    "AzureEntra": true,
     "ForceLogin": true
   },
 

--- a/frontend/altinn-support-dashboard.client/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Sidebar/Sidebar.tsx
@@ -49,7 +49,12 @@ const Sidebar: React.FC = () => {
     !authData.azureAuthActive ||
     authData.roles.includes("Dashboard.Core.Internal") ||
     authData.roles.includes("Dashboard.Core.External");
-
+  const hasDeveloperRole =
+    !authData.azureAuthActive || authData.roles.includes("Dashboard.Developer");
+  const hasTT02OrProductionRoles =
+    !authData.azureAuthActive ||
+    authData.roles.includes("Dashboard.PROD") ||
+    authData.roles.includes("Dashboard.TT02");
   return (
     <div className={classes.sidebarWrapper}>
       <div className={classes.dragHandle} onMouseDown={handleDragStart} />
@@ -90,18 +95,22 @@ const Sidebar: React.FC = () => {
           <Divider className={classes.divider} />
 
           <nav className={classes.nav}>
-            <NavItem
-              to="/dashboard"
-              title="Oppslag"
-              icon={<Buildings3Icon className={classes.icons} />}
-              isCollapsed={isCollapsed}
-            />
-            <NavItem
-              to="/manualrolesearch"
-              title="Manuelt rollesøk"
-              icon={<MagnifyingGlassIcon className={classes.icons} />}
-              isCollapsed={isCollapsed}
-            />
+            {hasTT02OrProductionRoles && (
+              <div>
+                <NavItem
+                  to="/dashboard"
+                  title="Oppslag"
+                  icon={<Buildings3Icon className={classes.icons} />}
+                  isCollapsed={isCollapsed}
+                />
+                <NavItem
+                  to="/manualrolesearch"
+                  title="Manuelt rollesøk"
+                  icon={<MagnifyingGlassIcon className={classes.icons} />}
+                  isCollapsed={isCollapsed}
+                />
+              </div>
+            )}
             <NavItem
               to="/resourcesearch"
               title="Ressurs søk"
@@ -114,6 +123,14 @@ const Sidebar: React.FC = () => {
               icon={<EnvelopeOpenIcon className={classes.icons} />}
               isCollapsed={isCollapsed}
             />
+            {hasDeveloperRole && (
+              <NavItem
+                to="/identifier-conversion"
+                title="ID-konvertering"
+                icon={<ArrowRightLeftIcon className={classes.icons} />}
+                isCollapsed={isCollapsed}
+              />
+            )}
             {hasInternalOrExternalCoreRoles && (
               <NavGroup
                 title="Core"
@@ -125,12 +142,6 @@ const Sidebar: React.FC = () => {
                   to="/notification"
                   title="Varsling Søk"
                   icon={<DatabaseIcon className={classes.icons} />}
-                  isCollapsed={isCollapsed}
-                />
-                <NavItem
-                  to="/identifier-conversion"
-                  title="ID-konvertering"
-                  icon={<ArrowRightLeftIcon className={classes.icons} />}
                   isCollapsed={isCollapsed}
                 />
               </NavGroup>

--- a/frontend/altinn-support-dashboard.client/src/components/Sidebar/SidebarEnvToggle.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Sidebar/SidebarEnvToggle.tsx
@@ -1,43 +1,14 @@
 import classes from "./styles/SideBarEnvToggle.module.css";
 import { useAppStore } from "../../stores/Appstore";
 import { Select, SelectOption } from "@digdir/designsystemet-react";
-import { useEffect } from "react";
-import { useAuthDetails } from "../../hooks/azureAuthHooks";
 
 const SidebarEnvToggle: React.FC = () => {
-  const environment = useAppStore((state) => state.environment);
+  const environment = useAppStore((state) => state.environment ?? "TT02");
   const setEnvironment = useAppStore((state) => state.setEnvironment);
-  const authDetails = useAuthDetails();
-  const userPolicies = authDetails?.data?.roles;
 
   const handleEnvironmentChange = (env: string) => {
     setEnvironment(env);
   };
-
-  useEffect(() => {
-    if (userPolicies == null) {
-      return;
-    }
-
-    if (
-      environment == "TT02" &&
-      !userPolicies.includes("Dashboard.TT02") &&
-      userPolicies.includes("Dashboard.PROD")
-    ) {
-      setEnvironment("PROD");
-    } else if (
-      environment == "PROD" &&
-      !userPolicies.includes("Dashboard.PROD") &&
-      userPolicies.includes("Dashboard.TT02")
-    ) {
-      setEnvironment("TT02");
-    }
-  }, [
-    authDetails?.data?.isLoggedIn,
-    environment,
-    setEnvironment,
-    userPolicies,
-  ]);
 
   return (
     <div className={classes.container}>
@@ -46,14 +17,8 @@ const SidebarEnvToggle: React.FC = () => {
         value={environment}
         onChange={(e) => handleEnvironmentChange(e.target.value)}
       >
-        {(!authDetails.data?.azureAuthActive ||
-          userPolicies?.includes("Dashboard.PROD")) && (
-          <SelectOption value="PROD">PROD</SelectOption>
-        )}
-        {(!authDetails.data?.azureAuthActive ||
-          userPolicies?.includes("Dashboard.TT02")) && (
-          <SelectOption value="TT02">TT02</SelectOption>
-        )}
+        <SelectOption value="PROD">PROD</SelectOption>
+        <SelectOption value="TT02">TT02</SelectOption>
         {import.meta.env.DEV && <SelectOption value="mock">MOCK</SelectOption>}
       </Select>
     </div>

--- a/frontend/altinn-support-dashboard.client/test/Sidebar/Sidebar.test.tsx
+++ b/frontend/altinn-support-dashboard.client/test/Sidebar/Sidebar.test.tsx
@@ -62,7 +62,12 @@ describe("Sidebar", () => {
     });
 
     vi.mocked(useAuthDetails).mockReturnValue({
-      data: { isLoggedIn: true, name: "Test User", azureAuthActive: true, roles: [] },
+      data: {
+        isLoggedIn: true,
+        name: "Test User",
+        azureAuthActive: true,
+        roles: [],
+      },
       isLoading: false,
     } as unknown as ReturnType<typeof useAuthDetails>);
   });
@@ -79,7 +84,7 @@ describe("Sidebar", () => {
     const { container } = render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(container.firstChild).toBeNull();
@@ -97,30 +102,17 @@ describe("Sidebar", () => {
     const { container } = render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(container.firstChild).toBeNull();
-  });
-
-  it("should render all navItems when expanded", () => {
-    render(
-      <MemoryRouter>
-        <Sidebar />
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByText("Oppslag")).toBeInTheDocument();
-    expect(screen.getByText("Manuelt rollesøk")).toBeInTheDocument();
-    expect(screen.getByText("Melding")).toBeInTheDocument();
-    expect(screen.getByText("Innstillinger")).toBeInTheDocument();
   });
 
   it("should show collapse button correctly when expanded", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.getByText("Minimer sidepanel")).toBeInTheDocument();
@@ -138,7 +130,7 @@ describe("Sidebar", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.queryByText("Oppslag")).not.toBeInTheDocument();
@@ -153,7 +145,7 @@ describe("Sidebar", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     const collapseButton = screen.getByRole("button", {
@@ -168,7 +160,7 @@ describe("Sidebar", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.getByText("Test User")).toBeInTheDocument();
@@ -186,7 +178,7 @@ describe("Sidebar", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.queryByText("Test User")).not.toBeInTheDocument();
@@ -204,7 +196,7 @@ describe("Sidebar", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.queryByText("EnvToggle")).not.toBeInTheDocument();
@@ -214,7 +206,7 @@ describe("Sidebar", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.getByText("EnvToggle")).toBeInTheDocument();
@@ -232,12 +224,12 @@ describe("Sidebar", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.queryByText("DateTime")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Logg ut/i }),
+      screen.queryByRole("button", { name: /Logg ut/i })
     ).not.toBeInTheDocument();
   });
 
@@ -245,12 +237,12 @@ describe("Sidebar", () => {
     render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.getByText("DateTime")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Logg ut/i }),
+      screen.getByRole("button", { name: /Logg ut/i })
     ).toBeInTheDocument();
   });
 
@@ -266,13 +258,13 @@ describe("Sidebar", () => {
     const { container } = render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     const img = container.querySelector("img");
     expect(img).toHaveAttribute(
       "src",
-      expect.stringContaining("asd_128_white.png"),
+      expect.stringContaining("asd_128_white.png")
     );
   });
 
@@ -280,7 +272,7 @@ describe("Sidebar", () => {
     const { container } = render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     const img = container.querySelector("img");
@@ -291,7 +283,7 @@ describe("Sidebar", () => {
     const { container } = render(
       <MemoryRouter>
         <Sidebar />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     const dragHandle = container.querySelector('[class*="dragHandle"]');
@@ -300,4 +292,3 @@ describe("Sidebar", () => {
     expect(mockHandleDragStart).toHaveBeenCalled();
   });
 });
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a generic developer role which can be assigned to tools which are meant for developers across from teams. ID-conversion is the first tool which has been given this role.

Changed some filter options in sidebar to filter out more tabs based on which roles the user has. Also deleted filter from env toggle since prod and TT02 can both be used even though you do not have these roles (id-conversion and resource search)
