### PR TITLE
Resolve access package codes to display names in rolesrights response

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Clients/Altinn3APiClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Altinn3APiClient.cs
@@ -314,10 +314,6 @@ public class Altinn3ApiClient : IAltinn3ApiClient
         var response = await client.GetAsync(requestUrl);
         var responseBody = await response.Content.ReadAsStringAsync();
 
-        if(response.StatusCode == HttpStatusCode.NotFound)
-        {
-            return string.Empty;
-        }
         if (!response.IsSuccessStatusCode)
         {
             throw new Exception($"Api request failed with status code {response.StatusCode}: {responseBody}");

--- a/backend/src/altinn-support-dashboard.backend/Clients/Altinn3APiClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Altinn3APiClient.cs
@@ -306,4 +306,23 @@ public class Altinn3ApiClient : IAltinn3ApiClient
         return responseBody;
     }
 
+    public async Task<string> GetAccessPackagesList(string environmentName)
+    {
+        var client = _clients[environmentName];
+        var requestUrl = $"accessmanagement/api/v1/meta/info/accesspackages/export";
+
+        var response = await client.GetAsync(requestUrl);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if(response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return string.Empty;
+        }
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Api request failed with status code {response.StatusCode}: {responseBody}");
+        }
+        return responseBody;
+    }
+
 }

--- a/backend/src/altinn-support-dashboard.backend/Clients/Interfaces/IAltinn3ApiClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Interfaces/IAltinn3ApiClient.cs
@@ -11,6 +11,7 @@ public interface IAltinn3ApiClient
     Task<string> GetOrganizationIdentifiers(List<string> orgNumbers, string environmentName);
     Task<string> GetOrganizationsPartyInfoByPartyId(List<int> partyIds, string environmentName);
     Task<string> GetAltinn2RolesList(string environmentName);
+    Task<string> GetAccessPackagesList(string environmentName);
 }
 
 

--- a/backend/src/altinn-support-dashboard.backend/Clients/Mocks/Data/altinn3-accesspackages.json
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Mocks/Data/altinn3-accesspackages.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Allment",
+    "areas": [
+      {
+        "name": "Skatt, avgift, regnskap og toll",
+        "packages": [
+          {
+            "name": "Skattenæring",
+            "urn": "urn:altinn:accesspackage:skatt-naering",
+            "description": "Denne tilgangspakken gir fullmakter til tjenester knyttet til skattenæring."
+          }
+        ]
+      },
+      {
+        "name": "Personal og lønn",
+        "packages": [
+          {
+            "name": "Lønn og personalarbeid",
+            "urn": "urn:altinn:accesspackage:lonn-og-personalarbeid",
+            "description": "Denne tilgangspakken gir fullmakter til tjenester knyttet til lønn og personalarbeid."
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/backend/src/altinn-support-dashboard.backend/Clients/Mocks/MockAltinn3ApiClient.cs
+++ b/backend/src/altinn-support-dashboard.backend/Clients/Mocks/MockAltinn3ApiClient.cs
@@ -51,6 +51,11 @@ public class MockAltinn3ApiClient(Altinn3ApiClient inner) : IAltinn3ApiClient
         MockUtils.IsMock(environmentName)
             ? Task.FromResult(MockUtils.Read("altinn3-altinn2-roles.json"))
             : inner.GetAltinn2RolesList(environmentName);
+    public Task<string> GetAccessPackagesList(string environmentName) =>
+    MockUtils.IsMock(environmentName)
+        ? Task.FromResult(MockUtils.Read("altinn3-accesspackages.json"))
+        : inner.GetAccessPackagesList(environmentName);
+
 }
 
 

--- a/backend/src/altinn-support-dashboard.backend/Models/altinn3/AccessPackagesDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/altinn3/AccessPackagesDto.cs
@@ -1,0 +1,18 @@
+public class AccessPackageGroupDto
+{
+    public string? Name { get; set; }
+    public List<AccessPackageAreaDto>? Areas {get; set; }
+}
+
+public class AccessPackageAreaDto
+{
+    public string? Name { get; set; }
+    public List<AccessPackageDto>? Packages {get; set; }
+}
+
+public class AccessPackageDto
+{
+    public string? Name { get; set; }
+    public string? Urn { get; set; }
+    public string? Description { get; set; }
+}

--- a/backend/src/altinn-support-dashboard.backend/Models/altinn3/AuthorizedPartyDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/altinn3/AuthorizedPartyDto.cs
@@ -5,7 +5,7 @@ public class AuthorizedPartyDto
     public string? Name { get; set; }
     public string? OrganizationNumber { get; set; }
     public string? PersonId { get; set; }
-    public string[]? AuthorizedAccessPackages { get; set; }
+    public List<string>? AuthorizedAccessPackages { get; set; }
     public List<string>? AuthorizedResources { get; set; }
     public List<string>? AuthorizedRoles { get; set; }
     public List<AuthorizedInstanceDto>? AuthorizedInstances { get; set; }

--- a/backend/src/altinn-support-dashboard.backend/Models/altinn3/RolesAndRightsDto.cs
+++ b/backend/src/altinn-support-dashboard.backend/Models/altinn3/RolesAndRightsDto.cs
@@ -4,7 +4,7 @@ public class RolesAndRightsDto
 {
     public string? Name { get; set; }
     public required string OrganizationNumber { get; set; }
-    public string[]? AuthorizedAccessPackages { get; set; }
+    public List<string>? AuthorizedAccessPackages { get; set; }
     public List<string>? AuthorizedResources { get; set; }
     public List<string>? AuthorizedRoles { get; set; }
     public List<AuthorizedInstanceDto>? AuthorizedInstances { get; set; }

--- a/backend/src/altinn-support-dashboard.backend/Services/Altinn3Service.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/Altinn3Service.cs
@@ -387,6 +387,19 @@ public class Altinn3Service : IAltinn3Service
                 }
                 catch (Exception e) { _logger.LogError($"Error converting resourceNames: {e}"); }
             }
+
+            if (roles.AuthorizedAccessPackages != null && roles.AuthorizedAccessPackages.Count >= 1)
+            {
+                try
+                {
+                    var accessPackageNames = await GetAccessPackageNamesFromUrns(roles.AuthorizedAccessPackages, environment);
+                    if (accessPackageNames != null)
+                    {
+                        roles.AuthorizedAccessPackages = accessPackageNames;
+                    }
+                }
+                catch (Exception e) { _logger.LogError($"Error converting accessPackageNames: {e}");}
+            }
         }
         return roles;
     }
@@ -535,6 +548,33 @@ public class Altinn3Service : IAltinn3Service
             }
         }
         return roleNames;
+    }
+
+    public async Task<List<AccessPackageDto>> GetAccessPackagesList(string environmentName)
+    {
+        return await _cache.GetOrCreateAsync<List<AccessPackageDto>>($"accessPackagesList_{environmentName}", async entry =>
+        {
+            var result = await _client.GetAccessPackagesList(environmentName);
+            var groups = JsonSerializer.Deserialize<List<AccessPackageGroupDto>>(result, jsonOptions)
+                ?? throw new Exception("Failed to deserialize access packages list for caching");
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1);
+            return groups
+                .SelectMany(g => g.Areas ?? [])
+                .SelectMany(a => a.Packages ?? [])
+                .ToList();
+        }) ?? throw new Exception("Cache returned null");
+    }
+
+    private async Task<List<string>> GetAccessPackageNamesFromUrns(List<string> urns, string environmentName)
+    {
+        var packages = await GetAccessPackagesList(environmentName);
+        return urns.Select(urn =>
+        {
+            var suffix = urn.Replace("urn:altinn:accesspackage:", "");
+            var match = packages.FirstOrDefault(p =>
+                p.Urn?.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) == true);
+            return match?.Name ?? urn;
+        }).ToList();
     }
 
 }

--- a/backend/src/altinn-support-dashboard.backend/Services/Altinn3Service.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/Altinn3Service.cs
@@ -567,12 +567,12 @@ public class Altinn3Service : IAltinn3Service
 
     private async Task<List<string>> GetAccessPackageNamesFromUrns(List<string> urns, string environmentName)
     {
+        const string accessPackageUrnPrefix = "urn:altinn:accesspackage:";
         var packages = await GetAccessPackagesList(environmentName);
         return urns.Select(urn =>
         {
-            var suffix = urn.Replace("urn:altinn:accesspackage:", "");
             var match = packages.FirstOrDefault(p =>
-                p.Urn?.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) == true);
+                string.Equals(p.Urn?.Replace(accessPackageUrnPrefix, ""), urn, StringComparison.OrdinalIgnoreCase));
             return match?.Name ?? urn;
         }).ToList();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Access packages in the roles-and-rights response were returned as raw codes (e.g. `skatt-naering`) instead of human-readable names. This adds a lookup so `AuthorizedAccessPackages` is resolved to display names the same way `AuthorizedRoles` and `AuthorizedResources` already are.

- Added `GetAccessPackagesList` to `IAltinn3ApiClient`/`Altinn3ApiClient`, calling the `accessmanagement/api/v1/meta/info/accesspackages/export` endpoint, with a matching mock implementation and mock data file.
- Added `AccessPackageGroupDto`/`AccessPackageAreaDto`/`AccessPackageDto` to model the (nested group → area → package) response shape.
- Added `Altinn3Service.GetAccessPackagesList`, cached for a day per environment since the list rarely changes, and `GetAccessPackageNamesFromUrns` to map each authorized package code to its display name (falls back to the raw code if no match is found).
- Wired the mapping into `GetRolesAndRightsAltinn3` alongside the existing role/resource name conversion.
- Changed `AuthorizedAccessPackages` from `string[]` to `List<string>` on `AuthorizedPartyDto`/`RolesAndRightsDto` for consistency with the other authorized-* lists.

## Related Issue(s)
- #796 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
