### PR TITLE
fix: stop contact-list email highlight from sticking to the wrong row

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/contacts/ContactInfoCell.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/contacts/ContactInfoCell.tsx
@@ -17,15 +17,14 @@ const ContactInfoCell: React.FC<ContactInfoCellProps> = ({
 }) => {
   const userInput = useDashboardStore((s) => s.query.replace(/\s/g, ""));
 
-  const [isBold, setIsBold] = useState<boolean>(false);
 
   //outlines if searchquery is part of the cell
 
-  useEffect(() => {
-    if (contact?.replace(/\s/g, "").toLowerCase() === userInput.toLowerCase()) {
-      setIsBold(true);
-    }
-  }, [contact, userInput]);
+  const isBold =
+    !!contact &&
+    userInput.length > 0 &&
+    contact.replace(/\s/g, "").toLowerCase().includes(userInput.toLowerCase());
+
   return (
     <div>
       {contactLastChanged && (

--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/contacts/ContactInfoCell.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/contacts/ContactInfoCell.tsx
@@ -3,7 +3,6 @@ import { useDashboardStore } from "../../../../stores/DashboardStore";
 import { Tooltip, Label } from "@digdir/designsystemet-react";
 
 import { formatDate } from "../../utils/dateUtils";
-import { useEffect, useState } from "react";
 import classes from "../../styles/ContactInfoCell.module.css";
 
 interface ContactInfoCellProps {

--- a/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/contacts/ContactsTable.tsx
+++ b/frontend/altinn-support-dashboard.client/src/components/Dashboard/components/contacts/ContactsTable.tsx
@@ -107,7 +107,7 @@ const ContactsTable: React.FC<ContactsTableProps> = ({
         <Table.Body>
           {sortedContacts.length > 0 ? (
             sortedContacts.map((contact, index) => (
-              <Table.Row key={`${contact.nationalIdentityNumber}-${index}`}>
+              <Table.Row key={contact.ssnToken ?? `${contact.email}-${contact.phone}-${index}`}>
                 <Table.Cell className={classes.tableCell}>
                   {contact.name}
                 </Table.Cell>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Contact-list email/phone highlighting could stick to the wrong row after a search, especially after sorting or filtering the table.
- Root cause: table rows were keyed by `nationalIdentityNumber`, which the backend always nulls out for redaction (`Altinn3Service.cs`), so the key effectively collapsed to just the array index. Any reorder (sort, filter, background refetch) made React reuse a row's component instance for a different contact.
- `ContactInfoCell`'s `isBold` was also stored in `useState` and only ever set to `true`, never reset to `false`, so a stale highlight from a previous contact could persist on a reused instance and display against the wrong person.
- Fix: key rows by `ssnToken` (falls back to `email`/`phone`/index) so identity tracks the actual contact, and derive `isBold` directly from props each render instead of latching it in state.


## Related Issue(s)
- #803 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
