### PR TITLE
821 add audit logging for notification searches

### DIFF
--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -34,8 +34,6 @@ public class NotificationsController : ControllerBase
     {
         if (!ValidationService.IsValidNotificationOrderId(orderId))
             return BadRequest(InvalidOrderIdMessage);
-        
-        _telemetryService.TrackOrderIdSearch("email", orderId, CurrentUserId, environmentName);
 
         var response = await _service.GetEmailNotificationsByOrderId(orderId, environmentName);
         return Ok(response);
@@ -46,8 +44,6 @@ public class NotificationsController : ControllerBase
     {
         if (!ValidationService.IsValidNotificationOrderId(orderId))
             return BadRequest(InvalidOrderIdMessage);
-
-        _telemetryService.TrackOrderIdSearch("sms", orderId, CurrentUserId, environmentName);
 
         var response = await _service.GetSmsNotificationsByOrderId(orderId, environmentName);
         return Ok(response);

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -1,3 +1,4 @@
+using altinn_support_dashboard.Server.Services;
 using altinn_support_dashboard.Server.Services.Interfaces;
 using altinn_support_dashboard.Server.Utils;
 using Microsoft.AspNetCore.Authorization;
@@ -17,18 +18,24 @@ public class NotificationsController : ControllerBase
 
     private readonly INotificationsService _service;
     private readonly IAltinn3Service _altinn3Service;
+    private readonly ITelemetryService _telemetryService;
 
-    public NotificationsController(INotificationsService service, IAltinn3Service altinn3Service)
+    public NotificationsController(INotificationsService service, IAltinn3Service altinn3Service, ITelemetryService telemetryService)
     {
         _service = service;
         _altinn3Service = altinn3Service;
+        _telemetryService = telemetryService;
     }
+
+    private string CurrentUserId => User.Identity?.Name ?? "unknown";
 
     [HttpGet("orderid/email/{orderId}")]
     public async Task<IActionResult> GetEmailNotificationsByOrderId([FromRoute] string environmentName, string orderId)
     {
         if (!ValidationService.IsValidNotificationOrderId(orderId))
             return BadRequest(InvalidOrderIdMessage);
+        
+        _telemetryService.TrackOrderIdSearch("email", orderId, CurrentUserId, environmentName);
 
         var response = await _service.GetEmailNotificationsByOrderId(orderId, environmentName);
         return Ok(response);
@@ -40,6 +47,8 @@ public class NotificationsController : ControllerBase
         if (!ValidationService.IsValidNotificationOrderId(orderId))
             return BadRequest(InvalidOrderIdMessage);
 
+        _telemetryService.TrackOrderIdSearch("sms", orderId, CurrentUserId, environmentName);
+
         var response = await _service.GetSmsNotificationsByOrderId(orderId, environmentName);
         return Ok(response);
     }
@@ -49,6 +58,8 @@ public class NotificationsController : ControllerBase
     {
         if (!ValidationService.IsValidNotificationOrderId(orderId))
             return BadRequest(InvalidOrderIdMessage);
+
+        _telemetryService.TrackOrderIdSearch("all", orderId, CurrentUserId, environmentName);
 
         var response = await _service.GetAllNotificationsByOrderId(orderId, environmentName);
         return Ok(response);
@@ -65,6 +76,9 @@ public class NotificationsController : ControllerBase
         {
             return BadRequest("Not a valid nin");
         }
+
+        _telemetryService.TrackNinSearch(nin, CurrentUserId, environmentName);
+
         var response = await _service.GetFutureNotificationsByNin(nin, from, to, environmentName);
         return Ok(response);
     }
@@ -80,6 +94,9 @@ public class NotificationsController : ControllerBase
         {
             return BadRequest("Not a valid Organization number");
         }
+
+        _telemetryService.TrackOrgNrSearch(orgNr, CurrentUserId, environmentName);
+        
         var response = await _service.GetFutureNotificationsByOrgNr(orgNr, from, to, environmentName);
         return Ok(response);
     }

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -112,6 +112,9 @@ public class NotificationsController : ControllerBase
         {
             return BadRequest("Not a valid PartyId");
         }
+
+        _telemetryService.TrackPartyIdSearch(partyId, CurrentUserId, environmentName);
+
         var response = await _service.GetFutureNotificationsByPartyId(partyId, from, to, environmentName);
         return Ok(response);
     }
@@ -127,6 +130,9 @@ public class NotificationsController : ControllerBase
         {
             return BadRequest("Not in a valid Guid format");
         }
+
+        _telemetryService.TrackPartyUuidSearch(partyUuid, CurrentUserId, environmentName);
+        
         var response = await _service.GetFutureNotificationsByPartyUuid(partyUuid, from, to, environmentName);
         return Ok(response);
     }

--- a/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
+++ b/backend/src/altinn-support-dashboard.backend/Controllers/NotificationsController.cs
@@ -55,7 +55,7 @@ public class NotificationsController : ControllerBase
         if (!ValidationService.IsValidNotificationOrderId(orderId))
             return BadRequest(InvalidOrderIdMessage);
 
-        _telemetryService.TrackOrderIdSearch("all", orderId, CurrentUserId, environmentName);
+        _telemetryService.TrackOrderIdSearch(orderId, CurrentUserId, environmentName);
 
         var response = await _service.GetAllNotificationsByOrderId(orderId, environmentName);
         return Ok(response);

--- a/backend/src/altinn-support-dashboard.backend/Services/Interfaces/ITelemetryService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/Interfaces/ITelemetryService.cs
@@ -4,4 +4,5 @@ public interface ITelemetryService
 {
     void TrackEvent(string eventName, IDictionary<string, string>? properties = null);
     void TrackSsnUnmasked(string userId, string environment, string ssn);
+    void TrackSearch(string featureArea, string searchType, string userId, string environment, IDictionary<string, string>? extra = null);
 }

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationSearchTelemetryExtensions.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationSearchTelemetryExtensions.cs
@@ -4,13 +4,13 @@ using System.Text;
 
 namespace altinn_support_dashboard.Server.Services;
 
-public static class NotificationsSearchTelemetryExtensions
+public static class NotificationSearchTelemetryExtensions
 {
     private const string FeatureArea = "notifications";
 
     public static void TrackOrderIdSearch(this ITelemetryService telemetry, string channel, string orderId, string userId, string environment)
     {
-        telemetry.TrackSearch(FeatureArea, $"order.Id{channel}", userId, environment, new Dictionary<string, string> { { "orderId", orderId } });
+        telemetry.TrackSearch(FeatureArea, $"orderId.{channel}", userId, environment, new Dictionary<string, string> { { "orderId", orderId } });
     }
 
     public static void TrackNinSearch(this ITelemetryService telemetry, string nin, string userId, string environment)

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationSearchTelemetryExtensions.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationSearchTelemetryExtensions.cs
@@ -10,7 +10,7 @@ public static class NotificationSearchTelemetryExtensions
 
     public static void TrackOrderIdSearch(this ITelemetryService telemetry, string channel, string orderId, string userId, string environment)
     {
-        telemetry.TrackSearch(FeatureArea, $"orderId.{channel}", userId, environment, new Dictionary<string, string> { { "orderId", orderId } });
+        telemetry.TrackSearch(FeatureArea, "orderId", userId, environment, new Dictionary<string, string> { { "orderId", orderId } });
     }
 
     public static void TrackNinSearch(this ITelemetryService telemetry, string nin, string userId, string environment)

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationSearchTelemetryExtensions.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationSearchTelemetryExtensions.cs
@@ -1,0 +1,37 @@
+using altinn_support_dashboard.Server.Services.Interfaces;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace altinn_support_dashboard.Server.Services;
+
+public static class NotificationsSearchTelemetryExtensions
+{
+    private const string FeatureArea = "notifications";
+
+    public static void TrackOrderIdSearch(this ITelemetryService telemetry, string channel, string orderId, string userId, string environment)
+    {
+        telemetry.TrackSearch(FeatureArea, $"order.Id{channel}", userId, environment, new Dictionary<string, string> { { "orderId", orderId } });
+    }
+
+    public static void TrackNinSearch(this ITelemetryService telemetry, string nin, string userId, string environment)
+    {
+        //To not have actual NIN in the logs, it gets hashed
+        var ninHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(nin)));
+        telemetry.TrackSearch(FeatureArea, "nin", userId, environment, new Dictionary<string, string> { { "ninHash", ninHash } });
+    }
+
+    public static void TrackOrgNrSearch(this ITelemetryService telemetry, string orgNr, string userId, string environment)
+    {
+        telemetry.TrackSearch(FeatureArea, "orgNr", userId, environment, new Dictionary<string, string> { { "orgNr", orgNr } });
+    }
+
+    public static void TrackPartyIdSearch(this ITelemetryService telemetry, string partyId, string userId, string environment)
+    {
+        telemetry.TrackSearch(FeatureArea, "partyId", userId, environment, new Dictionary<string,string> { { "partyId", partyId } });
+    }
+
+    public static void TrackPartyUuidSearch(this ITelemetryService telemetry, string partyUuid, string userId, string environment)
+    {
+        telemetry.TrackSearch(FeatureArea, "partyUuid", userId, environment, new Dictionary<string, string> { { "partyUuid", partyUuid } });
+    }
+}

--- a/backend/src/altinn-support-dashboard.backend/Services/NotificationSearchTelemetryExtensions.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/NotificationSearchTelemetryExtensions.cs
@@ -8,7 +8,7 @@ public static class NotificationSearchTelemetryExtensions
 {
     private const string FeatureArea = "notifications";
 
-    public static void TrackOrderIdSearch(this ITelemetryService telemetry, string channel, string orderId, string userId, string environment)
+    public static void TrackOrderIdSearch(this ITelemetryService telemetry, string orderId, string userId, string environment)
     {
         telemetry.TrackSearch(FeatureArea, "orderId", userId, environment, new Dictionary<string, string> { { "orderId", orderId } });
     }

--- a/backend/src/altinn-support-dashboard.backend/Services/TelemetryService.cs
+++ b/backend/src/altinn-support-dashboard.backend/Services/TelemetryService.cs
@@ -33,4 +33,25 @@ public class TelemetryService : ITelemetryService
             { "ssnHash", ssnHash }
         });
     }
+
+    public void TrackSearch(string featureArea, string searchType, string userId, string environment, IDictionary<string, string>? extra = null)
+    {
+        var properties = new Dictionary<string, string>
+        {
+            { "featureArea", featureArea},
+            { "searchType", searchType },
+            { "userId", userId },
+            { "environment", environment }
+        };
+
+        if (extra != null)
+        {
+            foreach (var kvp in extra)
+            {
+                properties[kvp.Key] = kvp.Value;
+            }
+        }
+
+        _telemetryClient?.TrackEvent("search", properties);
+    }
 }

--- a/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
@@ -1,5 +1,7 @@
+using System.Security.Claims;
 using altinn_support_dashboard.Server.Services.Interfaces;
 using AltinnSupportDashboard.Controllers;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Models.notifications;
 using Moq;
@@ -16,12 +18,26 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
         private readonly NotificationsController _controller;
         private readonly Mock<INotificationsService> _serviceMock;
         private readonly Mock<IAltinn3Service> _altinn3ServiceMock;
+        private readonly Mock<ITelemetryService> _telemetryServiceMock;
 
         public NotificationsControllerTests()
         {
             _serviceMock = new Mock<INotificationsService>();
             _altinn3ServiceMock = new Mock<IAltinn3Service>();
-            _controller = new NotificationsController(_serviceMock.Object, _altinn3ServiceMock.Object);
+            _telemetryServiceMock = new Mock<ITelemetryService>();
+            _controller = new NotificationsController(_serviceMock.Object, _altinn3ServiceMock.Object, _telemetryServiceMock.Object)
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext
+                    {
+                        User = new System.Security.Claims.ClaimsPrincipal(new ClaimsIdentity(new[]
+                        {
+                            new Claim(ClaimTypes.Name, "test-user")
+                        }, "TestAuth"))
+                    }
+                }
+            };
         }
 
         [Fact]
@@ -176,6 +192,42 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
                 .ThrowsAsync(new Exception("Service failure"));
 
             await Assert.ThrowsAsync<Exception>(() => _controller.GetFutureNotificationsByNin(EnvironmentName, "12345678901", null, null));
+        }
+
+        [Fact]
+        public async Task GetEmailNotificationsByOrderId_TrackSearch_WithOrderId()
+        {
+            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(ValidOrderId, EnvironmentName))
+                .ReturnsAsync(new NotificationOrderResponseDto { OrderId = ValidOrderId, SendersReference = "ref", Generated
+                = 1, Succeeded = 1, Notifications = []});
+            
+            await _controller.GetEmailNotificationsByOrderId(EnvironmentName, ValidOrderId);
+
+            _telemetryServiceMock.Verify(t => t.TrackSearch(
+                "notifications",
+                "orderId.email",
+                It.IsAny<string>(),
+                EnvironmentName,
+                It.Is<IDictionary<string, string>>(d => d["orderId"] == ValidOrderId)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetFutureNotificationsByNin_TracksSearch_WithHashedNin_NotRawNin()
+        {
+            const string nin = "12345678901";
+            _serviceMock.Setup(S => S.GetFutureNotificationsByNin(nin, null, null, EnvironmentName))
+                .ReturnsAsync(new List<FutureNotificationDto>());
+            
+            await _controller.GetFutureNotificationsByNin(EnvironmentName, nin, null, null);
+
+            _telemetryServiceMock.Verify(t => t.TrackSearch(
+                "notifications",
+                "nin",
+                It.IsAny<String>(),
+                EnvironmentName,
+                It.Is<IDictionary<string, string>>(d => d.ContainsKey("ninHash") && !d.Values.Contains(nin))),
+                Times.Once);
         }
     }
 }

--- a/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
+++ b/backend/test/altinn-support-dashboard.backend.Tests/Controllers/NotificationsControllerTests.cs
@@ -195,22 +195,24 @@ namespace altinn_support_dashboard.backend.Tests.Controllers
         }
 
         [Fact]
-        public async Task GetEmailNotificationsByOrderId_TrackSearch_WithOrderId()
+        public async Task GetAllNotificationsByOrderId_TracksSearch_WithOrderId()
         {
-            _serviceMock.Setup(s => s.GetEmailNotificationsByOrderId(ValidOrderId, EnvironmentName))
-                .ReturnsAsync(new NotificationOrderResponseDto { OrderId = ValidOrderId, SendersReference = "ref", Generated
-                = 1, Succeeded = 1, Notifications = []});
-            
-            await _controller.GetEmailNotificationsByOrderId(EnvironmentName, ValidOrderId);
+            _serviceMock.Setup(s => s.GetAllNotificationsByOrderId(ValidOrderId, EnvironmentName))
+                .ReturnsAsync(new List<NotificationOrderResponseDto>
+                {
+                    new() { OrderId = ValidOrderId, SendersReference = "ref", Generated = 1, Succeeded = 1, Notifications = [] }
+                });
+
+            await _controller.GetAllNotificationsByOrderId(EnvironmentName, ValidOrderId);
 
             _telemetryServiceMock.Verify(t => t.TrackSearch(
                 "notifications",
-                "orderId.email",
+                "orderId",
                 It.IsAny<string>(),
                 EnvironmentName,
                 It.Is<IDictionary<string, string>>(d => d["orderId"] == ValidOrderId)),
                 Times.Once);
-        }
+            }
 
         [Fact]
         public async Task GetFutureNotificationsByNin_TracksSearch_WithHashedNin_NotRawNin()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds a generic `TrackSearch(featureArea, searchType, userId, environment, extra)` method to `ITelemetryService`/`TelemetryService`, alongside the existing `TrackSsnUnmasked`, so all search activity across the app can eventually share one `customEvents` schema in Application Insights.
- Adds `NotificationSearchTelemetryExtensions` — typed wrapper methods (`TrackOrderIdSearch`, `TrackNinSearch`, `TrackOrgNrSearch`, `TrackPartyIdSearch`, `TrackPartyUuidSearch`) that call the generic `TrackSearch` with `featureArea: "notifications"`, so call sites in the controller stay typed instead of building raw dictionaries.
- Wires `ITelemetryService` into `NotificationsController` and calls the relevant tracking method from every search endpoint (order-id by email/SMS/all, NIN, org number, party ID, party UUID) before the underlying service call.
- NINs are hashed (SHA-256) before being logged, matching the existing pattern used for SSN unmasking — the raw NIN is never sent to Application Insights.

## Why
We currently have no audit trail for who searched what through `NotificationsController` — only SSN-unmasking events are logged today. This closes that gap for compliance and for investigating misuse, following the same telemetry pattern already established for SSN unmasking

## Related Issue(s)
- #821 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
