### PR TITLE
Changed from set size to fit to content

### DIFF
--- a/frontend/altinn-support-dashboard.client/src/pages/styles/IdentifierConversionPage.module.css
+++ b/frontend/altinn-support-dashboard.client/src/pages/styles/IdentifierConversionPage.module.css
@@ -16,5 +16,5 @@
 }
 
 .result {
-  max-width: 500px;
+  max-width: max-content;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Made the id-converter box fit the size of the longest string instead of being a set size

## Related Issue(s)
- #840 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
